### PR TITLE
Return PBm parameters P and Ms separately

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -61,7 +61,7 @@ StableRNGs = "1.0.2"
 StaticArrays = "1.9.13"
 StatsBase = "0.34.4"
 StatsFuns = "1.3.2"
-Test = "1.11.0"
+Test = "1.10"
 julia = "1.10"
 
 [workspace]

--- a/Project.toml
+++ b/Project.toml
@@ -23,6 +23,7 @@ StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [weakdeps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
@@ -60,6 +61,7 @@ StableRNGs = "1.0.2"
 StaticArrays = "1.9.13"
 StatsBase = "0.34.4"
 StatsFuns = "1.3.2"
+Test = "1.11.0"
 julia = "1.10"
 
 [workspace]

--- a/dev/doubleMM.jl
+++ b/dev/doubleMM.jl
@@ -15,16 +15,16 @@ import MLDataDevices, CUDA, cuDNN, GPUArraysCore
 
 rng = StableRNG(115)
 scenario = NTuple{0, Symbol}()
-scenario = (:omit_r0,)  # without omit_r0 ambiguous K2 estimated to high
-scenario = (:use_Flux, :use_gpu)
-scenario = (:use_Flux, :use_gpu, :omit_r0, :few_sites)
-scenario = (:use_Flux, :use_gpu, :omit_r0, :few_sites, :covarK2)
-scenario = (:use_Flux, :use_gpu, :omit_r0, :sites20, :covarK2)
-scenario = (:use_Flux, :use_gpu, :omit_r0)
-scenario = (:use_Flux, :use_gpu, :omit_r0, :covarK2)
+scenario = Val((:omit_r0,))  # without omit_r0 ambiguous K2 estimated to high
+scenario = Val((:use_Flux, :use_gpu))
+scenario = Val((:use_Flux, :use_gpu, :omit_r0, :few_sites))
+scenario = Val((:use_Flux, :use_gpu, :omit_r0, :few_sites, :covarK2))
+scenario = Val((:use_Flux, :use_gpu, :omit_r0, :sites20, :covarK2))
+scenario = Val((:use_Flux, :use_gpu, :omit_r0))
+scenario = Val((:use_Flux, :use_gpu, :omit_r0, :covarK2))
 # prob = DoubleMM.DoubleMMCase()
 
-gdev = :use_gpu ∈ scenario ? gpu_device() : identity
+gdev = :use_gpu ∈ HVI._val_value(scenario) ? gpu_device() : identity
 cdev = gdev isa MLDataDevices.AbstractGPUDevice ? cpu_device() : identity
 
 #------ setup synthetic data and training data loader
@@ -55,10 +55,12 @@ n_epoch = 80
     maxiters = n_batches_in_epoch * n_epoch);
 # update the problem with optimized parameters
 prob0o = probo;
-y_pred_global, y_pred, θMs = gf(prob0o, scenario);
-plt = scatterplot(θMs_true[1, :], θMs[1, :]);
+y_pred_global, y_pred, θMs = gf(prob0o; scenario, is_inferred=Val(true));
+# @descend_code_warntype gf(prob0o; scenario)
+#@usingany UnicodePlots
+plt = scatterplot(θMs_true'[:, 1], θMs[:, 1]);
 lineplot!(plt, 0, 1)
-scatterplot(θMs_true[2, :], θMs[2, :])
+scatterplot(θMs_true'[:,2], θMs[:,2])
 prob0o.θP
 #scatterplot(vec(y_true), vec(y_o))
 #scatterplot(vec(y_true), vec(y_pred))
@@ -93,7 +95,7 @@ end
     # and fit gf starting from true parameters
     prob = prob0
     g, ϕg0_cpu = get_hybridproblem_MLapplicator(prob; scenario)
-    ϕg0 = (:use_Flux ∈ scenario) ? gdev(ϕg0_cpu) : ϕg0_cpu
+    ϕg0 = (:use_Flux ∈ _val_value(scenario)) ? gdev(ϕg0_cpu) : ϕg0_cpu
     (; transP, transM) = get_hybridproblem_transforms(prob; scenario)
 
     function loss_g(ϕg, x, g, transM; gpu_handler = HVI.default_GPU_DataHandler)
@@ -161,8 +163,8 @@ n_epoch = 40
 prob1o = probo;
 n_sample_pred = 400
 #(; θ, y) = predict_hvi(rng, prob1o, xM, xP; scenario, n_sample_pred);
-(; θ, y) = predict_hvi(rng, prob1o; scenario, n_sample_pred);
-(θ1, y1) = (θ, y);
+(; y, θsP, θsMs)  = predict_hvi(rng, prob1o; scenario, n_sample_pred, is_inferred=Val(true));
+(y1, θsP1, θsMs1) = (y, θsP, θsMs);
 
 () -> begin # prediction with fitted parameters  (should be smaller than mean)
     y_pred_global, y_pred2, θMs = gf(prob1o, xM, xP; scenario)
@@ -192,17 +194,18 @@ prob2o = probo;
 () -> begin
     using JLD2
     #fname_probos = "intermediate/probos_$(last(scenario)).jld2"
-    fname_probos = "intermediate/probos800_$(last(scenario)).jld2"
+    fname_probos = "intermediate/probos800_$(last(HVI._val_value(scenario))).jld2"
     JLD2.save(fname_probos, Dict("prob1o" => prob1o, "prob2o" => prob2o))
     tmp = JLD2.load(fname_probos)
-    # get_train_loader function could not be restored with JLD2
+    # TODO replace function closure by Callable to store 
+    # closure function could not be restored with JLD2
     prob1o = HVI.update(tmp["prob1o"], get_train_loader = prob0.get_train_loader);
     prob2o = HVI.update(tmp["prob2o"], get_train_loader = prob0.get_train_loader);
 end
 
 () -> begin # load the non-covar scenario
     using JLD2
-    #fname_probos = "intermediate/probos_$(last(scenario)).jld2"
+    #fname_probos = "intermediate/probos_$(last(_val_value(scenario))).jld2"
     fname_probos = "intermediate/probos800_omit_r0.jld2"
     tmp = JLD2.load(fname_probos)
     # get_train_loader function could not be restored with JLD2
@@ -246,10 +249,11 @@ exp.(ϕunc_VI.coef_logσ2_ζMs[1, :])
 
 # test predicting correct obs-uncertainty of predictive posterior
 n_sample_pred = 400
-(; θ, y, entropy_ζ) = predict_hvi(rng, prob2o; scenario, n_sample_pred);
-(θ2, y2) = (θ, y)
+(; y, θsP, θsMs) = predict_hvi(rng, prob2o; scenario, n_sample_pred);
+(y2, θsP2, θsMs2) = (y, θsP, θsMs);
+
 size(y) # n_obs x n_site, n_sample_pred
-size(θ)  # n_θP + n_site * n_θM x n_sample
+size(θsMs)  # n_site x n_θM x n_sample
 σ_o_post = dropdims(std(y; dims = 3), dims = 3);
 σ_o = exp.(y_unc[:, 1] / 2)
 
@@ -264,11 +268,11 @@ plt = scatterplot(vec(y_true), vec(mean_y_pred));
 lineplot!(plt, 0, 2)
 mean(mean_y_pred - y_true) # still ok
 
-mean_θ = CA.ComponentVector(mean(CA.getdata(θ); dims = 2)[:, 1], CA.getaxes(θ[:, 1])[1])
-plt = scatterplot(θMs_true[1, :], mean_θ.Ms[1, :]);
+mean_θMs = CA.ComponentArray(mean(θsMs; dims = 3)[:,:,1], CA.getaxes(θMs_true'))
+plt = scatterplot(θMs_true'[:,1], mean_θMs[:,1]);
 lineplot!(plt, 0, 1)
-plt = scatterplot(θMs_true[2, :], mean_θ.Ms[2, :])
-histogram(θ[:P,:])
+plt = scatterplot(θMs_true'[:,2], mean_θMs[:,2])
+histogram(θsP)
 #scatter(fig[1,1], CA.getdata(θMs_true[1, :]), CA.getdata(mean_θ.Ms[1, :])); ablines!(fig[1,1], 0, 1)
 #@usingany AlgebraOfGraphices
 #fig = Figure()
@@ -320,10 +324,10 @@ end
 
 () -> begin # look at distribution of parameters, predictions, and likelihood and elob at one site
     function predict_site(probo, i_site)
-        (; θ, y, entropy_ζ) = predict_hvi(rng, probo, xM, xP; scenario, n_sample_pred)
+        (; y, θsP, θsMs, entropy_ζ) = predict_hvi(rng, probo; scenario, n_sample_pred)
         y_site = y[:, i_site, :]
-        θMs_i = map(i_rep -> θ[:Ms, i_rep][:, i_site], axes(θ, 2))
-        r1s = map(x -> x[1], θMs_i)
+        θMs_i = CA.ComponentArray(θsMs[i_site,:,:], (CA.getaxes(θMs_true)[1], CA.FlatAxis()))
+        r1s = θMs_i[:r1,:]
         # K1s = map(x -> x[2], θMs_i)
         # invt = map(Bijectors.inverse, get_hybridproblem_transforms(probo; scenario))
         # θPs = θ[:P,:]
@@ -348,6 +352,7 @@ end
 
     #@usingany CairoMakie
     #@usingany AlgebraOfGraphics
+    #@usingany DataFrames
     const aog = AlgebraOfGraphics
 
     # especially uncertainty is put to r1 (compensated by larger K1)
@@ -466,12 +471,15 @@ cor_ends = get_hybridproblem_cor_ends(prob; scenario)
 g, ϕg0 = get_hybridproblem_MLapplicator(prob; scenario)
 ϕunc0 = get_hybridproblem_ϕunc(prob; scenario)
 (; transP, transM) = get_hybridproblem_transforms(prob; scenario)
+hpints = HybridProblemInterpreters(prob; scenario)
 (; ϕ, transPMs_batch, interpreters, get_transPMs, get_ca_int_PMs) = init_hybrid_params(
-    θP, θM, cor_ends, ϕg0, n_site; transP, transM, ϕunc0);
+    θP, θM, cor_ends, ϕg0, hpints; transP, transM, ϕunc0);
 
-intm_PMs_gen = get_ca_int_PMs(n_site);
+intm_PMs_gen = get_int_PMs_site(hpints);
 #intm_PMs_gen = get_ca_int_PMs(100);
-trans_PMs_gen = get_transPMs(n_site);
+#trans_PMs_gen = get_transPMs(n_site);
+trans_Ms_gen = StackedArray(transM, n_site)
+
 #trans_PMs_gen = get_transPMs(100);
 
 """
@@ -483,9 +491,9 @@ transposeMs = (ζ, intm_PMs, back=false) -> begin
     Ms = back ? reshape(ζc.Ms, reverse(size(ζc.Ms))) : ζc.Ms
     ζct = vcat(CA.getdata(ζc.P), vec(CA.getdata(Ms)'))
 end
-θ_true = vcat(CA.getdata(θP_true), vec(CA.getdata(θMs_true)));
-ζ_true = log.(θ_true);
-θ0_true = transposeMs(θ_true, intm_PMs_gen);
+# θ_true = vcat(CA.getdata(θP_true), vec(CA.getdata(θMs_true)));
+# ζ_true = log.(θ_true);
+θ0_true = vcat(CA.getdata(θP_true), vec(CA.getdata(θMs_true'))); # note the transpose
 ζ0_true = log.(θ0_true);
 #transposeMs(θ0_true, intm_PMs_gen, true) == θ_true
 
@@ -504,16 +512,24 @@ chain = sample(model, NUTS(), MCMCThreads(), ceil(Integer,n_sample_NUTS/n_thread
 
 () -> begin
     using JLD2
-    fname = "intermediate/doubleMM_chain_zeta_$(last(scenario)).jld2"
+    fname = "intermediate/doubleMM_chain_zeta_$(last(HVI._val_value(scenario))).jld2"
     jldsave(fname, false, IOStream; chain)
     chain = load(fname, "chain"; iotype = IOStream);
+    n_sample_NUTS = size(Array(chain),1)
 end
 
 #ζi = first(eachrow(Array(chain)))
 f_allsites = get_hybridproblem_PBmodel(prob0; scenario, use_all_sites = true)
-ζs = mapreduce(ζi -> transposeMs(ζi, intm_PMs_gen, true), hcat, eachrow(Array(chain)));
-(; θ, y) = HVI.apply_f_trans(ζs, f_allsites, xP, trans_PMs_gen, intm_PMs_gen);
-(ζs_hmc, θ_hmc, y_hmc) = (ζs, θ, y);
+#ζs = mapreduce(ζi -> transposeMs(ζi, intm_PMs_gen, true), hcat, eachrow(Array(chain)));
+ζsP = Array(chain)[:,1:n_θP]'
+ζsMst = reshape(Array(chain)[:,(n_θP+1) : end], n_sample_NUTS, n_site, n_θM)
+ζsMs = permutedims(ζsMst, (2,3,1))
+# need to reshape according to generate_ζ
+ζsMs[:,:,1]  # first sample: n_site x n_par
+ζsMs[:,1,:]  # first parameter n_site x n_sample 
+
+(; y, θsP, θsMs) = HVI.apply_f_trans(ζsP, ζsMs, f_allsites, xP; transP, transM);
+(y_hmc, θsP_hmc, θsMs_hmc) = (; y, θsP, θsMs);
 
     
 () -> begin # check that the model predicts the same as HVI-code
@@ -548,15 +564,16 @@ y_inv11 = y[1, 1, :]
 histogram(y_inv11 .- y_o[1, 1])
 histogram(y_inv11 .- y_true[1, 1])  
 
-histogram(ζs[1, :])
-describe(pdf.(Ref(prior_ζ), ζs[1, :]))  # only small differences 
-pdf(prior_ζ, log(θ_true[1]))
+histogram(ζsP[1, :])
+describe(pdf.(Ref(prior_ζ), ζsP[1, :]))  # only small differences 
+pdf(prior_ζ, log(θP_true[1]))
 
-mean_θ = CA.ComponentVector(mean(CA.getdata(θ); dims = 2)[:, 1], CA.getaxes(θ[:, 1])[1])
-histogram(θ[:P, :] .- θP_true)  # all overestimated ? 
-plt = scatterplot(θMs_true[1, :], mean_θ.Ms[1, :]);
+mean_θP = CA.ComponentArray(mean(θsP; dims = 2)[:, 1], CA.getaxes(θP_true))
+mean_θMs = CA.ComponentArray(mean(θsMs; dims = 3)[:,:, 1], CA.getaxes(θMs_true'))
+histogram(θsP .- θP_true)  # all overestimated ? 
+plt = scatterplot(θMs_true'[:,1], mean_θMs[:,1]);
 lineplot!(plt, 0, 1)
-plt = scatterplot(θMs_true[2, :], mean_θ.Ms[2, :]);
+plt = scatterplot(θMs_true'[:,2], mean_θMs[:,2]);
 lineplot!(plt, 0, 1)
 
 #------------------ compare HVI vs HMC sample
@@ -570,28 +587,35 @@ lineplot!(plt, 0, 1)
         72 .* (x_inch, y_inch) ./ cfg.pt_per_unit # size_pt        
     end
 
-    ζs_hvi = log.(θ2)
-    ζs_hvi_indep = log.(θ2_indep)
-    int_pms = interpreters.PMs
-    par_pos = int_pms(1:length(int_pms))
+    ζsP_hvi = log.(θsP2)
+    ζsP_hvi_indep = log.(θsP2) # TODO rerun and reload replace θsP2
+    ζsP_hmc = log.(θsP_hmc)
+    ζsMs_hvi = log.(θsMs2)
+    ζsMs_hvi_indep = log.(θsMs2) # TODO rerun and reload replace θsMs2
+    ζsMs_hmc = log.(θsMs_hmc)
+    # int_pms = interpreters.PMs
+    # par_pos = int_pms(1:length(int_pms))
     i_sites = 1:10
     #i_sites = 6:10
     #i_sites = 11:15
-    scen = vcat(fill(:hvi,size(ζs_hvi,2)),fill(:hmc,size(ζs_hmc,2)),fill(:hvi_indep,size(ζs_hvi_indep,2)))
-    dfP = mapreduce(vcat, axes(θP,1)) do i_par
-        pos = par_pos.P[i_par]
+    scen = vcat(fill(:hvi,size(ζsP_hvi,2)),fill(:hmc,size(ζsP_hmc,2)),fill(:hvi_indep,size(ζsP_hvi_indep,2)))
+    dfP = mapreduce(vcat, axes(θP_true,1)) do i_par
+        #pos = par_pos.P[i_par]
         DataFrame(
-            value = vcat(ζs_hvi[pos,:], ζs_hmc[pos,:], ζs_hvi_indep[pos,:]), 
-            variable = keys(θP)[i_par],
+            value = vcat(ζsP_hvi[i_par, :], ζsP_hmc[i_par,:], ζsP_hvi_indep[i_par,:]), 
+            variable = keys(θP_true)[i_par],
             site = i_sites[1],
             Method = scen
         )
     end 
     dfMs = mapreduce(vcat, i_sites) do i_site 
         mapreduce(vcat, axes(θM,1)) do i_par
-            pos = par_pos.Ms[i_par, i_site]
+            #pos = par_pos.Ms[i_par, i_site]
             DataFrame(
-                value = vcat(ζs_hvi[pos,:], ζs_hmc[pos,:], ζs_hvi_indep[pos,:]),
+                value = vcat(
+                    ζsMs_hvi[i_site,i_par,:], 
+                    ζsMs_hmc[i_site,i_par,:], 
+                    ζsMs_hvi_indep[i_site,i_par,:]),
                 variable = keys(θM)[i_par],
                 site = i_site,
                 Method = scen
@@ -627,7 +651,7 @@ lineplot!(plt, 0, 1)
     fg = draw!(fig, plt, facet=(; linkxaxes=:minimal, linkyaxes=:none,), axis=(xlabelvisible=false,));
     fig
     save("tmp.svg", fig)
-    save_with_config("intermediate/compare_hmc_hvi_sites_$(last(scenario))", fig; makie_config)
+    save_with_config("intermediate/compare_hmc_hvi_sites_$(last(HVI._val_value(scenario)))", fig; makie_config)
 
     plt = (data(subset(df, :Method => ByRow(∈((:hvi, :hvi_indep))))) * mapping(:value=> (x -> x ) => "", color=:Method) * AlgebraOfGraphics.density(datalimits=extrema) +
            data(df_true) * mapping(:value) * visual(VLines; color=:blue, linestyle=:dash)) * 
@@ -636,7 +660,7 @@ lineplot!(plt, 0, 1)
     fg = draw!(fig, plt, facet=(; linkxaxes=:minimal, linkyaxes=:none,), axis=(xlabelvisible=false,));
     fig
     save("tmp.svg", fig)
-    save_with_config("intermediate/compare_hvi_indep_sites_$(last(scenario))", fig; makie_config)
+    save_with_config("intermediate/compare_hvi_indep_sites_$(last(HVI._val_value(scenario)))", fig; makie_config)
 
     # 
     # compare density of predictions
@@ -695,6 +719,7 @@ lineplot!(plt, 0, 1)
         axis=(xlabelvisible=false,yticklabelsvisible=false));
     legend!(fig[1,3], f, ; tellwidth=false, halign=:right, valign=:top) # , margin=(-10, -10, 10, 10)
     fig
+    save("tmp.svg", fig)
     save_with_config("intermediate/compare_hmc_hvi_sites_y_$(last(scenario))", fig; makie_config)
     # hvi predicts y better, hmc fails for quite a few obs: 3,5,6
 
@@ -718,177 +743,115 @@ end
 end
     
 
-#---- do an DEMC inversion of the PBM model with parameters at constrained scale
-# construct a Normal prior that ranges roughly across 1e-2 to 10
-# prior_θ = fit(LogNormal, @qp_ll(1e-2), @qp_uu(10))
-# prior_θn = (n) -> MvLogNormal(fill(prior_θ.μ, n), PDiagMat(fill(abs2(prior_θ.σ), n)))
-prior_θ = Normal(0, 10)
-prior_θn = (n) -> MvNormal(fill(prior_θ.μ, n), PDiagMat(fill(abs2(prior_θ.σ), n)))
-prior_θn(3)
-prob = HVI.update(prob0o);
 
-(; θM, θP) = get_hybridproblem_par_templates(prob; scenario)
-n_θM, n_θP = length.((θM, θP))
-f = get_hybridproblem_PBmodel(prob; scenario)
+() -> begin # depr---- do an DEMC inversion of the PBM model with parameters at constrained scale
+    # construct a Normal prior that ranges roughly across 1e-2 to 10
+    # prior_θ = fit(LogNormal, @qp_ll(1e-2), @qp_uu(10))
+    # prior_θn = (n) -> MvLogNormal(fill(prior_θ.μ, n), PDiagMat(fill(abs2(prior_θ.σ), n)))
+    prior_θ = Normal(0, 10)
+    prior_θn = (n) -> MvNormal(fill(prior_θ.μ, n), PDiagMat(fill(abs2(prior_θ.σ), n)))
+    prior_θn(3)
+    prob = HVI.update(prob0o);
 
-@model function fsites_uc(
-        y, ::Type{T} = Float64; f, n_θP, n_θM, σ_o, n_obs = length(σ_o)) where {T}
-    n_obs, n_site = size(y)
-    prior_θP = prior_θn(n_θP)
-    prior_θM_sites = fill(prior_θn(n_site), n_θM)
-    θP ~ prior_θP #MvNormal(n_θP, 10.0)
-    # CAUTION: order of vectorizing matrix depends on order of ~
-    # need to assign each variable in first site first, then second site, ...
-    #   need to construct different MvNormal prior if std differs by variable
-    # or need to take care when extracting samples or specifying initial conditions
-    θMs = Matrix{T}(undef, n_θM, n_site)
-    # the first loop vectorizes θMs by columns but is much slower
-    # for i_site in 1:n_site
-    #     ζMs[:, i_site] ~ prior_ζn(n_θM) #MvNormal(n_site, 10.0)
-    # end
-    # this loop is faster, but vectorizes θMs by rows in parameter vector
-    for i_par in 1:n_θM
-        θMs[i_par, :] ~ prior_θM_sites[i_par]
+    (; θM, θP) = get_hybridproblem_par_templates(prob; scenario)
+    n_θM, n_θP = length.((θM, θP))
+    f = get_hybridproblem_PBmodel(prob; scenario)
+
+    @model function fsites_uc(
+            y, ::Type{T} = Float64; f, n_θP, n_θM, σ_o, n_obs = length(σ_o)) where {T}
+        n_obs, n_site = size(y)
+        prior_θP = prior_θn(n_θP)
+        prior_θM_sites = fill(prior_θn(n_site), n_θM)
+        θP ~ prior_θP #MvNormal(n_θP, 10.0)
+        # CAUTION: order of vectorizing matrix depends on order of ~
+        # need to assign each variable in first site first, then second site, ...
+        #   need to construct different MvNormal prior if std differs by variable
+        # or need to take care when extracting samples or specifying initial conditions
+        θMs = Matrix{T}(undef, n_θM, n_site)
+        # the first loop vectorizes θMs by columns but is much slower
+        # for i_site in 1:n_site
+        #     ζMs[:, i_site] ~ prior_ζn(n_θM) #MvNormal(n_site, 10.0)
+        # end
+        # this loop is faster, but vectorizes θMs by rows in parameter vector
+        for i_par in 1:n_θM
+            θMs[i_par, :] ~ prior_θM_sites[i_par]
+        end
+        # this fills in rows first, but is also slower- why?    
+        #ζMs[:] ~ prior_ζn(n_θM * n_site) 
+        # assume σ_o known, see f_MM
+        #σ_o ~ truncated(Normal(0, 1); lower=0)
+        y_pred = f(θP, θMs, xP)[2] # first is global return
+        #i_obs = 1
+        for i_obs in 1:n_obs
+            #pdf(MvNormal(y_pred[i_obs,:], σ_o[i_obs]),y[i_obs,:])
+            y[i_obs, :] ~ MvNormal(y_pred[i_obs, :], σ_o[i_obs]) # single value σ instead of variance
+        end
+        #Main.@infiltrate_main # step to second time 
+        # θMs_MCc[:,:,1] # checking row- or column-order of θMs
+        # exp.(ζMs)
+        y_pred
     end
-    # this fills in rows first, but is also slower- why?    
-    #ζMs[:] ~ prior_ζn(n_θM * n_site) 
-    # assume σ_o known, see f_MM
-    #σ_o ~ truncated(Normal(0, 1); lower=0)
-    y_pred = f(θP, θMs, xP)[2] # first is global return
-    #i_obs = 1
-    for i_obs in 1:n_obs
-        #pdf(MvNormal(y_pred[i_obs,:], σ_o[i_obs]),y[i_obs,:])
-        y[i_obs, :] ~ MvNormal(y_pred[i_obs, :], σ_o[i_obs]) # single value σ instead of variance
+    model_uc = fsites_uc(y_o; f, n_θP, n_θM, σ_o)
+
+    () -> begin # check that the model predicts the same as HVI-code
+        _parnames = Symbol.(vcat([
+            "θP[1]"], ["θMs[1, :][$i]" for i in 1:n_site], ["θMs[2, :][$i]" for i in 1:n_site]))
+        #chain0 = Chains(transposeMs(ζ_true, intm_PMs_gen)', _parnames);
+        chain0 = Chains(θ0_true', _parnames); # transpose here only for chain array
+        y0inv = generated_quantities(model_uc, chain0)[1, 1]
+        y0pred = f(θP_true,  θMs_true, xP)[2]
+        y0pred .- y_true 
+        y0inv .- y_true
     end
-    #Main.@infiltrate_main # step to second time 
-    # θMs_MCc[:,:,1] # checking row- or column-order of θMs
-    # exp.(ζMs)
-    y_pred
-end
-model_uc = fsites_uc(y_o; f, n_θP, n_θM, σ_o)
 
-() -> begin # check that the model predicts the same as HVI-code
-    _parnames = Symbol.(vcat([
-        "θP[1]"], ["θMs[1, :][$i]" for i in 1:n_site], ["θMs[2, :][$i]" for i in 1:n_site]))
-    #chain0 = Chains(transposeMs(ζ_true, intm_PMs_gen)', _parnames);
-    chain0 = Chains(θ0_true', _parnames); # transpose here only for chain array
-    y0inv = generated_quantities(model_uc, chain0)[1, 1]
-    y0pred = f(θP_true,  θMs_true, xP)[2]
-    y0pred .- y_true 
-    y0inv .- y_true
-end
+    
+    #θ0_true from above, tools from above
 
- 
-#θ0_true from above, tools from above
+    # takes long
+    n_sample_NUTS = 800
+    #n_sample_NUTS = 24
+    n_threads = 8
+    chain = sample(model_uc, NUTS(), MCMCThreads(), ceil(Integer,n_sample_NUTS/n_threads), 
+        n_threads, initial_params = fill(θ0_true .+ 0.001, n_threads))
 
-# takes long
-n_sample_NUTS = 800
-#n_sample_NUTS = 24
-n_threads = 8
-chain = sample(model_uc, NUTS(), MCMCThreads(), ceil(Integer,n_sample_NUTS/n_threads), 
-    n_threads, initial_params = fill(θ0_true .+ 0.001, n_threads))
-
-() -> begin
-    using JLD2
-    jldsave("intermediate/doubleMM_chain_theta.jld2", false, IOStream; chain)
-    chain = load("intermediate/doubleMM_chain_theta.jld2", "chain"; iotype = IOStream)
-    # plot chain as above
-end
-
-#θi = first(eachrow(Array(chain)))
-θs = mapreduce(θi -> transposeMs(θi, intm_PMs_gen, true), hcat, eachrow(Array(chain)));
-(; θ, y) = HVI.apply_f_trans(θs, f, xP, Stacked(elementwise(identity)), intm_PMs_gen);
-
-
-mean_y_invθ = map(mean, eachslice(y; dims = (1, 2)));
-#describe(mean_y_pred - y_o)
-histogram(vec(mean_y_invθ) - vec(y_true)) # predictions centered around y_o (or y_true)
-plt = scatterplot(vec(y_true), vec(mean_y_invθ));
-lineplot!(plt, 0, 2)
-mean(mean_y_invθ - y_true) # still ok
-
-# first site, first prediction
-y_inv11 = y[1, 1, :]
-histogram(y_inv11 .- y_o[1, 1])
-histogram(y_inv11 .- y_true[1, 1])  
-
-histogram(θs[1, :])
-describe(pdf.(Ref(prior_θ), θs[1, :]))  # only small differences 
-pdf(prior_θ, log(θ_true[1]))
-
-mean_θ = CA.ComponentVector(mean(CA.getdata(θ); dims = 2)[:, 1], CA.getaxes(θ[:, 1])[1])
-histogram(θ[:P, :] .- θP_true)  # all overestimated ? 
-plt = scatterplot(θMs_true[1, :], mean_θ.Ms[1, :]);
-lineplot!(plt, 0, 1)
-plt = scatterplot(θMs_true[2, :], mean_θ.Ms[2, :]);
-lineplot!(plt, 0, 1)
-
-
-
-
-
-
-
-
-
-
-#---- depr?
-size(chain)
-θc = Array(chain)'
-θinv = CA.ComponentArray(θc, (CA.getaxes(θ[:, 1])[1], CA.Axis(i = 1:size(θc, 2))))
-mean_θinv = CA.ComponentVector(
-    mean(CA.getdata(θinv); dims = 2)[:, 1], CA.getaxes(θ[:, 1])[1])
-
-@assert chain[:, 1, :1] == CA.getdata(θinv[:P, :][:K2, :])
-θP_true
-plot = histogram(CA.getdata(θinv[:P, :][:K2, :]))
-
-plt = scatterplot(θMs_true[1, :], mean_θinv.Ms[1, :]);
-lineplot!(plt, 0, 1);
-plt = scatterplot(θMs_true[2, :], mean_θinv.Ms[2, :])
-
-y_true = f(θP_true, θMs_true, xP)[2]
-yinv = map(i -> f(θinv[:P, i], θinv[:Ms, i], xP)[2], axes(θinv, 2)) |> stack
-histogram(yinv[1, 1, :])
-y_true[1, 1]
-
-tmp = generated_quantities(model_uc, chain[1:10, :, :])
-
-
-# reshape θMs (site x par) -> (par x site)
-_intm_PMs = ComponentArrayInterpreter(
-    CA.ComponentVector(P = θP_true, Ms = vec(CA.getdata(θMs_true))), (n_sample_NUTS,))
-extract_parameters_fsites = (chain) -> begin
-    Ac = _intm_PMs(transpose(Array(chain)))
-    #θM = Ac[:Ms,:][:,1]
-    θMs = mapslices(CA.getdata(Ac[:Ms, :]), dims = 1) do θM
-        # (site x par) -> (par x site)
-        vec(reshape(θM, n_site, :)')
+    () -> begin
+        using JLD2
+        jldsave("intermediate/doubleMM_chain_theta.jld2", false, IOStream; chain)
+        chain = load("intermediate/doubleMM_chain_theta.jld2", "chain"; iotype = IOStream)
+        # plot chain as above
     end
-    vcat(Ac[:P, :], θMs)
-end
 
-#ζs_MC = transpose(max.(-10.0,Array(chain)))
-#ζs_MC = transpose(Array(chain))
-ζs_MC = extract_parameters_fsites(chain)
-θs_MC = exp.(ζs_MC)
+    #θi = first(eachrow(Array(chain)))
+    θs = mapreduce(θi -> transposeMs(θi, intm_PMs_gen, true), hcat, eachrow(Array(chain)));
+    (; θ, y) = HVI.apply_f_trans(θs, f, xP, Stacked(elementwise(identity)), intm_PMs_gen);
 
-y_pred = y_pred_gen = stack(generated_quantities(model, chain)[:, 1])
 
-#ax_θPMs =  _get_ComponentArrayInterpreter_axes(int_θPMs)
-#intm_PMs = ComponentArrayInterpreter(ax_θPMs, n_sample_NUTS)
-intm_PMs = ComponentArrayInterpreter(
-    CA.ComponentVector(P = 1:n_θP, Ms = 1:(n_θM * n_site_batch)), (n_sample_NUTS,))
-intm_Ps = ComponentArrayInterpreter(θP_true, (n_sample_NUTS,))
-intm_Ms = ComponentArrayInterpreter(θM_true, (n_site_batch, n_sample_NUTS))
-θs_MCc = intm_PMs(θs_MC)
-θMs_MCc = intm_Ms(θs_MCc[:Ms, :])
-θPs_MCc = intm_Ps(θs_MCc[:P, :])
-ζs_MCc = intm_PMs(ζs_MC)
-ζMs_MCc = intm_Ms(ζs_MCc[:Ms, :])
-ζP_MCc = intm_Ps(ζs_MCc[:P, :])
+    mean_y_invθ = map(mean, eachslice(y; dims = (1, 2)));
+    #describe(mean_y_pred - y_o)
+    histogram(vec(mean_y_invθ) - vec(y_true)) # predictions centered around y_o (or y_true)
+    plt = scatterplot(vec(y_true), vec(mean_y_invθ));
+    lineplot!(plt, 0, 2)
+    mean(mean_y_invθ - y_true) # still ok
 
-# inspect correlation between physical parameter K and ML-parameter r at first (or ith) site
+    # first site, first prediction
+    y_inv11 = y[1, 1, :]
+    histogram(y_inv11 .- y_o[1, 1])
+    histogram(y_inv11 .- y_true[1, 1])  
+
+    histogram(θs[1, :])
+    describe(pdf.(Ref(prior_θ), θs[1, :]))  # only small differences 
+    pdf(prior_θ, log(θ_true[1]))
+
+    mean_θ = CA.ComponentVector(mean(CA.getdata(θ); dims = 2)[:, 1], CA.getaxes(θ[:, 1])[1])
+    histogram(θ[:P, :] .- θP_true)  # all overestimated ? 
+    plt = scatterplot(θMs_true[1, :], mean_θ.Ms[1, :]);
+    lineplot!(plt, 0, 1)
+    plt = scatterplot(θMs_true[2, :], mean_θ.Ms[2, :]);
+    lineplot!(plt, 0, 1)
+end  # depr DEMC constrained scale
+
+
+# TODO inspect correlation between physical parameter K and ML-parameter r at first (or ith) site
 
 mean_ζP_MC = mapslices(mean, CA.getdata(ζP_MCc), dims = 2)[:, 1]
 var_ζP_MC = map(x -> var(x; corrected = false), eachrow(ζP_MCc))

--- a/dev/doubleMM.jl
+++ b/dev/doubleMM.jl
@@ -512,7 +512,7 @@ end
 #ζi = first(eachrow(Array(chain)))
 f_allsites = get_hybridproblem_PBmodel(prob0; scenario, use_all_sites = true)
 ζs = mapreduce(ζi -> transposeMs(ζi, intm_PMs_gen, true), hcat, eachrow(Array(chain)));
-(; θ, y) = HVI.predict_ζf(ζs, f_allsites, xP, trans_PMs_gen, intm_PMs_gen);
+(; θ, y) = HVI.apply_f_trans(ζs, f_allsites, xP, trans_PMs_gen, intm_PMs_gen);
 (ζs_hmc, θ_hmc, y_hmc) = (ζs, θ, y);
 
     
@@ -522,7 +522,7 @@ f_allsites = get_hybridproblem_PBmodel(prob0; scenario, use_all_sites = true)
     #chain0 = Chains(transposeMs(ζ_true, intm_PMs_gen)', _parnames);
     chain0 = Chains(ζ0_true', _parnames); # transpose here only for chain array
     y0inv = generated_quantities(model, chain0)[1, 1]
-    y0pred = HVI.predict_y(ζ_true, xP, f, trans_PMs_gen, intm_PMs_gen)[2]
+    y0pred = HVI.apply_f_trans(ζ_true, xP, f, trans_PMs_gen, intm_PMs_gen)[2]
     y0pred .- y_true 
     y0inv .- y_true
 end
@@ -797,7 +797,7 @@ end
 
 #θi = first(eachrow(Array(chain)))
 θs = mapreduce(θi -> transposeMs(θi, intm_PMs_gen, true), hcat, eachrow(Array(chain)));
-(; θ, y) = HVI.predict_ζf(θs, f, xP, Stacked(elementwise(identity)), intm_PMs_gen);
+(; θ, y) = HVI.apply_f_trans(θs, f, xP, Stacked(elementwise(identity)), intm_PMs_gen);
 
 
 mean_y_invθ = map(mean, eachslice(y; dims = (1, 2)));

--- a/dev/doubleMM.jl
+++ b/dev/doubleMM.jl
@@ -160,8 +160,8 @@ n_epoch = 40
 # update the problem with optimized parameters, including uncertainty
 prob1o = probo;
 n_sample_pred = 400
-#(; θ, y) = predict_gf(rng, prob1o, xM, xP; scenario, n_sample_pred);
-(; θ, y) = predict_gf(rng, prob1o; scenario, n_sample_pred);
+#(; θ, y) = predict_hvi(rng, prob1o, xM, xP; scenario, n_sample_pred);
+(; θ, y) = predict_hvi(rng, prob1o; scenario, n_sample_pred);
 (θ1, y1) = (θ, y);
 
 () -> begin # prediction with fitted parameters  (should be smaller than mean)
@@ -210,7 +210,7 @@ end
     prob2o_indep = HVI.update(tmp["prob2o"], get_train_loader = prob0.get_train_loader);
     # test predicting correct obs-uncertainty of predictive posterior
     n_sample_pred = 400
-    (; θ, y, entropy_ζ) = predict_gf(rng, prob2o_indep, xM, xP; scenario, n_sample_pred);
+    (; θ, y, entropy_ζ) = predict_hvi(rng, prob2o_indep, xM, xP; scenario, n_sample_pred);
     (θ2_indep, y2_indep) = (θ, y)
     #(θ2_indep, y2_indep) = (θ2, y2)  # workaround to use covarK2 when loading failed
 end
@@ -241,12 +241,12 @@ end
 #ζMs_VI = g_flux(xM_gpu, ζ_VIc.ϕg |> Flux.gpu) |> Flux.cpu
 ϕunc_VI = interpreters.unc(ζ_VIc.unc)
 ϕunc_VI.ρsM
-exp.(ϕunc_VI.logσ2_logP)
+exp.(ϕunc_VI.logσ2_ζP)
 exp.(ϕunc_VI.coef_logσ2_ζMs[1, :])
 
 # test predicting correct obs-uncertainty of predictive posterior
 n_sample_pred = 400
-(; θ, y, entropy_ζ) = predict_gf(rng, prob2o; scenario, n_sample_pred);
+(; θ, y, entropy_ζ) = predict_hvi(rng, prob2o; scenario, n_sample_pred);
 (θ2, y2) = (θ, y)
 size(y) # n_obs x n_site, n_sample_pred
 size(θ)  # n_θP + n_site * n_θM x n_sample
@@ -320,7 +320,7 @@ end
 
 () -> begin # look at distribution of parameters, predictions, and likelihood and elob at one site
     function predict_site(probo, i_site)
-        (; θ, y, entropy_ζ) = predict_gf(rng, probo, xM, xP; scenario, n_sample_pred)
+        (; θ, y, entropy_ζ) = predict_hvi(rng, probo, xM, xP; scenario, n_sample_pred)
         y_site = y[:, i_site, :]
         θMs_i = map(i_rep -> θ[:Ms, i_rep][:, i_site], axes(θ, 2))
         r1s = map(x -> x[1], θMs_i)

--- a/dev/doubleMM.jl
+++ b/dev/doubleMM.jl
@@ -911,7 +911,7 @@ y_pred = stack(map(eachcol(θs_MC)) do θ
     θc = int_θPMs(θ)
     #θP, θMs = @view(θ[1:n_θP]), reshape(@view(θ[n_θP+1:end, :]), n_θM, :)
     θP, θMs = θc.θP, θc.θMs
-    y_pred_i = applyf(f_doubleMM, θMs, θP)
+    y_pred_i = map_f_each_site(f_doubleMM, θMs, θP)
 end)
 #hcat(y_pred[:,1,1], y_pred_gen[:,1,1])
 

--- a/dev/doubleMM.jl
+++ b/dev/doubleMM.jl
@@ -242,7 +242,7 @@ end
 ϕunc_VI = interpreters.unc(ζ_VIc.unc)
 ϕunc_VI.ρsM
 exp.(ϕunc_VI.logσ2_logP)
-exp.(ϕunc_VI.coef_logσ2_logMs[1, :])
+exp.(ϕunc_VI.coef_logσ2_ζMs[1, :])
 
 # test predicting correct obs-uncertainty of predictive posterior
 n_sample_pred = 400

--- a/ext/HybridVariationalInferenceCUDAExt.jl
+++ b/ext/HybridVariationalInferenceCUDAExt.jl
@@ -77,7 +77,7 @@ function uutri2vec_gpu!(v::Union{CUDA.CuVector,CUDA.CuDeviceVector}, X::Abstract
     return nothing # important
 end
 
-function HVI._create_random(rng, v::CUDA.CuVector{T,M}, dims...) where {T,M}
+function HVI._create_randn(rng, v::CUDA.CuVector{T,M}, dims...) where {T,M}
     # ignores rng
     # https://discourse.julialang.org/t/help-using-cuda-zygote-and-random-numbers/123458/4?u=bgctw
     res = ChainRulesCore.@ignore_derivatives CUDA.randn(dims...)

--- a/ext/HybridVariationalInferenceCUDAExt.jl
+++ b/ext/HybridVariationalInferenceCUDAExt.jl
@@ -77,10 +77,11 @@ function uutri2vec_gpu!(v::Union{CUDA.CuVector,CUDA.CuDeviceVector}, X::Abstract
     return nothing # important
 end
 
-function HVI._create_random(rng, ::CUDA.CuVector{T}, dims...) where {T}
+function HVI._create_random(rng, v::CUDA.CuVector{T,M}, dims...) where {T,M}
     # ignores rng
     # https://discourse.julialang.org/t/help-using-cuda-zygote-and-random-numbers/123458/4?u=bgctw
-    ChainRulesCore.@ignore_derivatives CUDA.randn(dims...)
+    res = ChainRulesCore.@ignore_derivatives CUDA.randn(dims...)
+    res::CUDA.CuArray{T, length(dims),M}
 end
 
 

--- a/ext/HybridVariationalInferenceFluxExt.jl
+++ b/ext/HybridVariationalInferenceFluxExt.jl
@@ -18,7 +18,8 @@ end
 
 function HVI.apply_model(app::FluxApplicator, x, ϕ)
     m = app.rebuild(ϕ)
-    m(x)
+    res = m(x)
+    res
 end
 
 # struct FluxGPUDataHandler <: AbstractGPUDataHandler end

--- a/ext/HybridVariationalInferenceFluxExt.jl
+++ b/ext/HybridVariationalInferenceFluxExt.jl
@@ -38,7 +38,7 @@ end
 
 function HVI.construct_3layer_MLApplicator(
         rng::AbstractRNG, prob::HVI.AbstractHybridProblem, ::Val{:Flux};
-        scenario::NTuple = ())
+        scenario::Val{scen}) where scen
     (;θM) = get_hybridproblem_par_templates(prob; scenario)
     n_out = length(θM)
     n_covar = get_hybridproblem_n_covar(prob; scenario)
@@ -46,7 +46,7 @@ function HVI.construct_3layer_MLApplicator(
     n_input = n_covar + n_pbm_covars
     #(; n_covar, n_θM) = get_hybridproblem_sizes(prob; scenario)
     float_type = get_hybridproblem_float_type(prob; scenario)
-    is_using_dropout = :use_dropout ∈ scenario
+    is_using_dropout = :use_dropout ∈ scen
     is_using_dropout && error("dropout scenario not supported with Flux yet.")
     g_chain = Flux.Chain(
         # dense layer with bias that maps to 8 outputs and applies `tanh` activation

--- a/ext/HybridVariationalInferenceSimpleChainsExt.jl
+++ b/ext/HybridVariationalInferenceSimpleChainsExt.jl
@@ -19,14 +19,14 @@ HVI.apply_model(app::SimpleChainsApplicator, x, ϕ) = app.m(x, ϕ)
 
 function HVI.construct_3layer_MLApplicator(
     rng::AbstractRNG, prob::HVI.AbstractHybridProblem, ::Val{:SimpleChains};
-    scenario::NTuple = ())
+    scenario::Val{scen}) where scen
     n_covar = get_hybridproblem_n_covar(prob; scenario)
     n_pbm_covars = length(get_hybridproblem_pbmpar_covars(prob; scenario))
     n_input = n_covar + n_pbm_covars
     FloatType = get_hybridproblem_float_type(prob; scenario)
     (;θM) = get_hybridproblem_par_templates(prob; scenario)
     n_out = length(θM)
-    is_using_dropout = :use_dropout ∈ scenario
+    is_using_dropout = :use_dropout ∈ scen
     g_chain = if is_using_dropout
         SimpleChain(
             static(n_input), # input dimension (optional)

--- a/src/AbstractHybridProblem.jl
+++ b/src/AbstractHybridProblem.jl
@@ -40,7 +40,8 @@ returns a Tuple of
 """
 function get_hybridproblem_MLapplicator end
 
-function get_hybridproblem_MLapplicator(prob::AbstractHybridProblem; scenario = ())
+function get_hybridproblem_MLapplicator(
+    prob::AbstractHybridProblem; scenario::Val{scen} = Val(())) where scen
     get_hybridproblem_MLapplicator(Random.default_rng(), prob; scenario)
 end
 
@@ -202,13 +203,13 @@ end
 Put relevant parts of the DataLoader to gpu, depending on scenario.
 """
 function gdev_hybridproblem_dataloader(dataloader::MLUtils.DataLoader;
-    scenario = (), 
+    scenario::Val{scen} = Val(()), 
     gdev = gpu_device(),
-    gdev_M = :use_gpu ∈ scenario ? gdev : identity,
-    gdev_P = :f_on_gpu ∈ scenario ? gdev : identity,
+    gdev_M = :use_gpu ∈ _val_value(scenario) ? gdev : identity,
+    gdev_P = :f_on_gpu ∈ _val_value(scenario) ? gdev : identity,
     batchsize = dataloader.batchsize,
     partial = dataloader.partial
-    )
+    ) where scen
     xM, xP, y_o, y_unc, i_sites = dataloader.data
     xM_dev = gdev_M(xM)
     xP_dev, y_o_dev, y_unc_dev = (gdev_P(xP), gdev_P(y_o), gdev_P(y_unc)) 

--- a/src/ComponentArrayInterpreter.jl
+++ b/src/ComponentArrayInterpreter.jl
@@ -209,15 +209,6 @@ function ComponentArrayInterpreter(ints::NamedTuple)
     return (intc)
 end
 
-function _construct_invervals(;lengths) 
-    reduce((agg,length) -> _add_interval(;agg, length), 
-        Iterators.tail(lengths), init=Val((1:_val_value(first(lengths)),)))    
-end
-function _add_interval(;agg::Val{ranges}, length::Val{l}) where {ranges,l}
-    ind_before = last(last(ranges))
-    Val((ranges...,ind_before .+ (1:l)))
-end
-_val_value(::Val{x}) where x = x
 
 # not exported, but required for testing
 _get_ComponentArrayInterpreter_axes(::StaticComponentArrayInterpreter{AX}) where {AX} = AX

--- a/src/ComponentArrayInterpreter.jl
+++ b/src/ComponentArrayInterpreter.jl
@@ -50,7 +50,7 @@ end
 # also does not save allocations
 # function StaticComponentArrayInterpreter(; kwargs...)
 #     ints = values(kwargs)
-#     axc = combine_axes(ints)
+#     axc = compose_axes(ints)
 #     intc = StaticComponentArrayInterpreter{(axc,)}()
 #     return(intc)
 # end
@@ -117,17 +117,17 @@ The other constructors allow constructing arrays with additional dimensions.
 function ComponentArrayInterpreter(; kwargs...)
     ComponentArrayInterpreter(values(kwargs))
 end
-# function ComponentArrayInterpreter(component_shapes::NamedTuple)
-#     component_counts = map(prod, component_shapes)
-#     n = sum(component_counts)
-#     x = 1:n
-#     is_end = cumsum(component_counts)
-#     is_start = (0, is_end[1:(end-1)]...) .+ 1
-#     #g = (x[i_start:i_end] for (i_start, i_end) in zip(is_start, is_end))
-#     g = (reshape(x[i_start:i_end], shape) for (i_start, i_end, shape) in zip(is_start, is_end, component_shapes))
-#     xc = CA.ComponentVector(; zip(propertynames(component_counts), g)...)
-#     ComponentArrayInterpreter(xc)
-# end
+function ComponentArrayInterpreter(component_shapes::NamedTuple)
+    component_counts = map(prod, component_shapes)
+    n = sum(component_counts)
+    x = 1:n
+    is_end = cumsum(component_counts)
+    is_start = (0, is_end[1:(end-1)]...) .+ 1
+    #g = (x[i_start:i_end] for (i_start, i_end) in zip(is_start, is_end))
+    g = (reshape(x[i_start:i_end], shape) for (i_start, i_end, shape) in zip(is_start, is_end, component_shapes))
+    xc = CA.ComponentVector(; zip(propertynames(component_counts), g)...)
+    ComponentArrayInterpreter(xc)
+end
 
 function ComponentArrayInterpreter(vc::CA.AbstractComponentArray)
     ComponentArrayInterpreter(CA.getaxes(vc))
@@ -202,9 +202,13 @@ function ComponentArrayInterpreter(n_dims1::Tuple{}, n_dims2::Tuple{})
 end
 
 # concatenate several 1d ComponentArrayInterpreters
-function ComponentArrayInterpreter(ints::NamedTuple)
+function compose_interpreters(; kwargs...)
+    compose_interpreters(values(kwargs))
+end
+
+function compose_interpreters(ints::NamedTuple)
     axtuples = map(x -> CA.getaxes(x), ints)
-    axc = combine_axes(axtuples)
+    axc = compose_axes(axtuples)
     intc = ComponentArrayInterpreter((axc,))
     return (intc)
 end

--- a/src/ComponentArrayInterpreter.jl
+++ b/src/ComponentArrayInterpreter.jl
@@ -174,7 +174,7 @@ end
     stack_ca_int(cai::AbstractComponentArrayInterpreter, ::Val{n_dims})
 
 Interpret the first dimension of an Array as a ComponentArray. Provide the Tuple
-of following dimesions by a value type, e.g. `Val((n_col, n_z))`.
+of following dimensions by a value type, e.g. `Val((n_col, n_z))`.
 """
 function stack_ca_int(
     cai::IT, ::Val{n_dims}) where {IT<:AbstractComponentArrayInterpreter,n_dims}
@@ -217,7 +217,10 @@ end
 # ambuiguity with two empty Tuples (edge prob that does not make sense)
 # Empty ComponentVector with no other array dimensions -> empty componentVector
 function ComponentArrayInterpreter(n_dims1::Tuple{}, n_dims2::Tuple{})
-    ComponentArrayInterpreter(CA.ComponentVector())
+    ComponentArrayInterpreter((CA.Axis(),))
+end
+function StaticComponentArrayInterpreter(n_dims1::Tuple{}, n_dims2::Tuple{})
+    StaticComponentArrayInterpreter{(CA.Axis(),)}()
 end
 
 # concatenate several 1d ComponentArrayInterpreters

--- a/src/ComponentArrayInterpreter.jl
+++ b/src/ComponentArrayInterpreter.jl
@@ -45,6 +45,20 @@ function as_ca(v::AbstractArray, ::StaticComponentArrayInterpreter{AX}) where {A
     CA.ComponentArray(vr, AX)::CA.ComponentArray{eltype(v)}
 end
 
+function StaticComponentArrayInterpreter(component_shapes::NamedTuple)
+    axs = map(component_shapes) do valx
+        x = _val_value(valx)
+        ax = x isa Integer ? CA.Shaped1DAxis((x,)) : CA.ShapedAxis(x)
+        (ax,)
+    end
+    axc = compose_axes(axs)
+    StaticComponentArrayInterpreter{(axc,)}()
+end
+function StaticComponentArrayInterpreter(ca::CA.ComponentArray)
+    ax = CA.getaxes(ca)
+    StaticComponentArrayInterpreter{ax}()
+end
+
 # concatenate from several other ArrayInterpreters, keep static
 # did not manage to get it inferred, better use get_concrete(ComponentArrayInterpreter)
 # also does not save allocations
@@ -118,7 +132,7 @@ function ComponentArrayInterpreter(; kwargs...)
     ComponentArrayInterpreter(values(kwargs))
 end
 function ComponentArrayInterpreter(component_shapes::NamedTuple)
-    component_counts = map(prod, component_shapes)
+    #component_counts = map(prod, component_shapes)
     # avoid constructing a template first, but create axes 
     # n = sum(component_counts)
     # x = 1:n
@@ -129,7 +143,7 @@ function ComponentArrayInterpreter(component_shapes::NamedTuple)
     # xc = CA.ComponentVector(; zip(propertynames(component_counts), g)...)
     # #nt = NamedTuple{propertynames(component_counts)}(g)
     # ComponentArrayInterpreter(xc)
-    axs = map(x -> (length(x) == 1 ? CA.Shaped1DAxis((x,)) : CA.ShapedAxis(x),), component_shapes)
+    axs = map(x -> (x isa Integer ? CA.Shaped1DAxis((x,)) : CA.ShapedAxis(x),), component_shapes)
     ax = compose_axes(axs)
     m1 = ComponentArrayInterpreter((ax,))
 end

--- a/src/ComponentArrayInterpreter.jl
+++ b/src/ComponentArrayInterpreter.jl
@@ -71,7 +71,7 @@ struct ComponentArrayInterpreter <: AbstractComponentArrayInterpreter
 end
 
 function as_ca(v::AbstractArray, cai::ComponentArrayInterpreter) 
-    vr = reshape(v, _axis_length.(cai.axes))
+    vr = reshape(CA.getdata(v), _axis_length.(cai.axes))
     CA.ComponentArray(vr, cai.axes)
 end
 

--- a/src/DoubleMM/f_doubleMM.jl
+++ b/src/DoubleMM/f_doubleMM.jl
@@ -177,7 +177,7 @@ function HVI.get_hybridproblem_PBmodel(prob::DoubleMMCase; scenario::NTuple = ()
         pos_xP = get_positions(int_xP1)
         function f_doubleMM_with_global(θP::AbstractVector, θMs::AbstractMatrix, xP)
             @assert size(xP,2) == n_site_batch
-            @assert size(θMs,2) == n_site_batch
+            @assert size(θMs,1) == n_site_batch
             # # convert vector of tuples to tuple of matricesByRows
             # # need to supply xP as vectorOfTuples to work with DataLoader
             # # k = first(keys(xP[1]))
@@ -194,7 +194,7 @@ function HVI.get_hybridproblem_PBmodel(prob::DoubleMMCase; scenario::NTuple = ()
             #xPM = map(p -> CA.getdata(xP[p,:])', pos_xP)
             xPM = map(p -> CA.getdata(xP)'[:,p], pos_xP)
             θFixd = (θP isa GPUArraysCore.AbstractGPUVector) ? θFix_dev : θFix
-            θ = hcat(CA.getdata(θP[isP]), CA.getdata(θMs)', θFixd)
+            θ = hcat(CA.getdata(θP[isP]), CA.getdata(θMs), θFixd)
             pred_sites = f_doubleMM(θ, xPM, intθ)'
             pred_global = eltype(pred_sites)[]
             return pred_global, pred_sites
@@ -260,7 +260,7 @@ function HVI.gen_hybridproblem_synthetic(rng::AbstractRNG, prob::DoubleMMCase;
     xP = int_xPn(vcat(repeat(xP_S1,1,n_site),repeat(xP_S2,1,n_site)))
     #xP[:S1,:]
     θP = par_templates.θP
-    y_global_true, y_true = f(θP, θMs_true, xP)
+    y_global_true, y_true = f(θP, θMs_true', xP) # TODO transpose θMs_true generally
     σ_o = FloatType(0.01)
     #σ_o = FloatType(0.002)
     logσ2_o = FloatType(2) .* log.(σ_o)

--- a/src/DoubleMM/f_doubleMM.jl
+++ b/src/DoubleMM/f_doubleMM.jl
@@ -1,7 +1,7 @@
 struct DoubleMMCase <: AbstractHybridProblem end
 
-const θP = CA.ComponentVector{Float32}(r0=0.3, K2=2.0)
-const θM = CA.ComponentVector{Float32}(r1=0.5, K1=0.2)
+const θP = CA.ComponentVector{Float32}(r0 = 0.3, K2 = 2.0)
+const θM = CA.ComponentVector{Float32}(r1 = 0.5, K1 = 0.2)
 const θall = vcat(θP, θM)
 
 const θP_nor0 = θP[(:K2,)]
@@ -9,7 +9,7 @@ const θP_nor0 = θP[(:K2,)]
 const xP_S1 = Float32[0.5, 0.5, 0.5, 0.5, 0.4, 0.3, 0.2, 0.1]
 const xP_S2 = Float32[1.0, 3.0, 4.0, 5.0, 5.0, 5.0, 5.0, 5.0]
 
-int_xP1 = ComponentArrayInterpreter(CA.ComponentVector(S1=xP_S1, S2=xP_S2))
+int_xP1 = ComponentArrayInterpreter(CA.ComponentVector(S1 = xP_S1, S2 = xP_S2))
 
 # const transP = elementwise(exp)
 # const transM = elementwise(exp)
@@ -37,7 +37,8 @@ function f_doubleMM(θ::AbstractVector, x, intθ)
     return (y)
 end
 
-function f_doubleMM(θ::AbstractMatrix, x::NamedTuple, intθ::HVI.AbstractComponentArrayInterpreter)
+function f_doubleMM(
+        θ::AbstractMatrix{T}, x::NamedTuple, intθ::HVI.AbstractComponentArrayInterpreter) where T
     # provide θ for n_row sites
     # provide x.S1 as Matrix n_site x n_obs
     # extract parameters not depending on order, i.e whether they are in θP or θM
@@ -46,9 +47,11 @@ function f_doubleMM(θ::AbstractMatrix, x::NamedTuple, intθ::HVI.AbstractCompon
     @assert size(x.S1) == size(x.S2)   # same number of observations
     #@assert length(x.s2 == n_obs)
     # problems on AD on GPU with indexing CA may be related to printing result, use ";"
+    VT = typeof(θ[:,1])   # workaround for non-stable Symbol-indexing CAMatrix 
+    #VT = first(Base.return_types(getindex, Tuple{typeof(θ),typeof(Colon()),typeof(1)}))
     (r0, r1, K1, K2) = map((:r0, :r1, :K1, :K2)) do par
         # vector will be repeated when broadcasted by a matrix
-        CA.getdata(θc[:, par])
+        CA.getdata(θc[:, par]) ::VT
     end
     # r0 = CA.getdata(θc[:,:r0])  # vector will be repeated when broadcasted by a matrix
     # r1 = CA.getdata(θc[:,:r1])
@@ -80,10 +83,11 @@ end
 #         return (y)
 # end
 
-function HVI.get_hybridproblem_par_templates(::DoubleMMCase; scenario::Val{scen}) where {scen}
+function HVI.get_hybridproblem_par_templates(
+        ::DoubleMMCase; scenario::Val{scen}) where {scen}
     if (:omit_r0 ∈ scen)
         #return ((; θP = θP_nor0, θM, θf = θP[(:K2r)]))
-        return ((; θP=θP_nor0, θM))
+        return ((; θP = θP_nor0, θM))
     end
     #(; θP, θM, θf = eltype(θP)[])
     (; θP, θM)
@@ -102,43 +106,53 @@ function HVI.get_hybridproblem_priors(::DoubleMMCase; scenario::Val{scen}) where
     Dict(keys(θall) .=> fit.(LogNormal, θall, QuantilePoint.(θall .* 3, 0.95)))
 end
 
-function HVI.get_hybridproblem_MLapplicator(prob::HVI.DoubleMM.DoubleMMCase; scenario::Val{scen}) where {scen}
+function HVI.get_hybridproblem_MLapplicator(
+        prob::HVI.DoubleMM.DoubleMMCase; scenario::Val{scen}) where {scen}
     rng = StableRNGs.StableRNG(111)
     get_hybridproblem_MLapplicator(rng, prob; scenario)
 end
 
 function HVI.get_hybridproblem_MLapplicator(
-    rng::AbstractRNG, prob::HVI.DoubleMM.DoubleMMCase; scenario::Val{scen}) where {scen}
+        rng::AbstractRNG, prob::HVI.DoubleMM.DoubleMMCase; scenario::Val{scen},
+        use_all_sites = false
+) where {scen}
     ml_engine = select_ml_engine(; scenario)
     g_nomag, ϕ_g0 = construct_3layer_MLApplicator(rng, prob, ml_engine; scenario)
     # construct normal distribution from quantiles at unconstrained scale
     priors_dict = get_hybridproblem_priors(prob; scenario)
+    (; θM) = get_hybridproblem_par_templates(prob; scenario)
     priors = [priors_dict[k] for k in keys(θM)]
     (; transM) = get_hybridproblem_transforms(prob; scenario)
-    g = NormalScalingModelApplicator(g_nomag, priors, transM, eltype(ϕ_g0))
+    lowers, uppers = HVI.get_quantile_transformed(
+        priors::AbstractVector{<:Distribution}, transM)
+    n_site, n_batch = get_hybridproblem_n_site_and_batch(prob; scenario)
+    n_site_batch = use_all_sites ? n_site : n_batch
+    g = NormalScalingModelApplicator(
+        g_nomag, lowers, uppers, eltype(ϕ_g0))
     return g, ϕ_g0
 end
 
-function HVI.get_hybridproblem_pbmpar_covars(::DoubleMMCase; scenario::Val{scen}) where {scen}
+function HVI.get_hybridproblem_pbmpar_covars(
+        ::DoubleMMCase; scenario::Val{scen}) where {scen}
     if (:covarK2 ∈ scen)
         return (:K2,)
     end
     ()
 end
 
-
-function HVI.get_hybridproblem_transforms(prob::DoubleMMCase; scenario::Val{scen}) where {scen}
+function HVI.get_hybridproblem_transforms(
+        prob::DoubleMMCase; scenario::Val{scen}) where {scen}
     _θP, _θM = get_hybridproblem_par_templates(prob; scenario)
     if (:stackedMS ∈ scen)
-        return (; transP=Stacked((HVI.Exp(),), (1:length(_θP),)),
-            transM=Stacked((identity, HVI.Exp(),), (1:1, 2:length(_θM),)))
+        return (; transP = Stacked((HVI.Exp(),), (1:length(_θP),)),
+            transM = Stacked((identity, HVI.Exp()), (1:1, 2:length(_θM))))
     elseif (:transIdent ∈ scen)
         # identity transformations, should AD on GPU
-        return (; transP=Stacked((identity,), (1:length(_θP),)),
-            transM=Stacked((identity,), (1:length(_θM),)))
+        return (; transP = Stacked((identity,), (1:length(_θP),)),
+            transM = Stacked((identity,), (1:length(_θM),)))
     end
-    (; transP=Stacked((HVI.Exp(),), (1:length(_θP),)),
-        transM=Stacked((HVI.Exp(),), (1:length(_θM),)))
+    (; transP = Stacked((HVI.Exp(),), (1:length(_θP),)),
+        transM = Stacked((HVI.Exp(),), (1:length(_θM),)))
 end
 
 # function HVI.get_hybridproblem_sizes(::DoubleMMCase; scenario::Val{scen}) where scen
@@ -168,8 +182,8 @@ end
 # end
 
 function HVI.get_hybridproblem_PBmodel(prob::DoubleMMCase; scenario::Val{scen},
-    use_all_sites=false,
-    gdev=:f_on_gpu ∈ scen ? gpu_device() : identity,
+        use_all_sites = false,
+        gdev = :f_on_gpu ∈ HVI._val_value(scenario) ? gpu_device() : identity
 ) where {scen}
     n_site, n_batch = get_hybridproblem_n_site_and_batch(prob; scenario)
     n_site_batch = use_all_sites ? n_site : n_batch
@@ -218,7 +232,6 @@ function HVI.get_hybridproblem_PBmodel(prob::DoubleMMCase; scenario::Val{scen},
     end
 end
 
-
 function HVI.get_hybridproblem_neg_logden_obs(::DoubleMMCase; scenario::Val)
     neg_logden_indep_normal
 end
@@ -227,14 +240,13 @@ end
 #     return Float32
 # end
 
-
 # two observations more?
 # const xP_S1 = Float32[0.5, 0.5, 0.5, 0.5, 0.5, 0.4, 0.3, 0.1]
 # const xP_S2 = Float32[1.0, 2.0, 3.0, 4.0, 5.0, 5.0, 5.0, 5.0]
 
 HVI.get_hybridproblem_n_covar(prob::DoubleMMCase; scenario::Val) = 5
 function HVI.get_hybridproblem_n_site_and_batch(prob::DoubleMMCase;
-    scenario::Val{scen}) where {scen}
+        scenario::Val{scen}) where {scen}
     n_batch = 20
     n_site = 800
     if (:few_sites ∈ scen)
@@ -246,26 +258,27 @@ function HVI.get_hybridproblem_n_site_and_batch(prob::DoubleMMCase;
 end
 
 function HVI.get_hybridproblem_train_dataloader(prob::DoubleMMCase; scenario::Val,
-    rng::AbstractRNG=StableRNG(111), kwargs...
+        rng::AbstractRNG = StableRNG(111), kwargs...
 )
     n_site, n_batch = get_hybridproblem_n_site_and_batch(prob; scenario)
     construct_dataloader_from_synthetic(rng, prob; scenario, n_batch, kwargs...)
 end
 
 function HVI.gen_hybridproblem_synthetic(rng::AbstractRNG, prob::DoubleMMCase;
-    scenario::Val{scen}) where {scen}
+        scenario::Val{scen}) where {scen}
     n_covar_pc = 2
     n_site, n_batch = get_hybridproblem_n_site_and_batch(prob; scenario)
     n_covar = get_hybridproblem_n_covar(prob; scenario)
     n_θM = length(θM)
     FloatType = get_hybridproblem_float_type(prob; scenario)
     par_templates = get_hybridproblem_par_templates(prob; scenario)
+    #XXTODO transform θMs_true
     xM, θMs_true0 = gen_cov_pred(rng, FloatType, n_covar_pc, n_covar, n_site, n_θM;
-        rhodec=8, is_using_dropout=false)
+        rhodec = 8, is_using_dropout = false)
     int_θMs_sites = ComponentArrayInterpreter(θM, (n_site,))
     # normalize to be distributed around the prescribed true values
     θMs_true = int_θMs_sites(scale_centered_at(θMs_true0, θM, FloatType(0.1)))
-    f = get_hybridproblem_PBmodel(prob; scenario, gdev=identity, use_all_sites=true)
+    f = get_hybridproblem_PBmodel(prob; scenario, gdev = identity, use_all_sites = true)
     #xP = fill((; S1 = xP_S1, S2 = xP_S2), n_site)
     int_xPn = ComponentArrayInterpreter(int_xP1, (n_site,))
     xP = int_xPn(vcat(repeat(xP_S1, 1, n_site), repeat(xP_S2, 1, n_site)))
@@ -280,13 +293,13 @@ function HVI.gen_hybridproblem_synthetic(rng::AbstractRNG, prob::DoubleMMCase;
     y_o = y_true .+ randn(rng, FloatType, size(y_true)) .* σ_o
     (;
         xM,
-        θP_true=θP,
+        θP_true = θP,
         θMs_true,
         xP,
         y_global_true,
         y_true,
         y_global_o,
         y_o,
-        y_unc=fill(logσ2_o, size(y_o))
+        y_unc = fill(logσ2_o, size(y_o))
     )
 end

--- a/src/DoubleMM/f_doubleMM.jl
+++ b/src/DoubleMM/f_doubleMM.jl
@@ -191,7 +191,8 @@ function HVI.get_hybridproblem_PBmodel(prob::DoubleMMCase; scenario::NTuple = ()
             # make sure the same order of columns as in intθ
             # reshape big matrix into NamedTuple of drivers S1 and S2 
             #   for broadcasting need sites in rows
-            xPM = map(p -> CA.getdata(xP[p,:])', pos_xP)
+            #xPM = map(p -> CA.getdata(xP[p,:])', pos_xP)
+            xPM = map(p -> CA.getdata(xP)'[:,p], pos_xP)
             θFixd = (θP isa GPUArraysCore.AbstractGPUVector) ? θFix_dev : θFix
             θ = hcat(CA.getdata(θP[isP]), CA.getdata(θMs)', θFixd)
             pred_sites = f_doubleMM(θ, xPM, intθ)'

--- a/src/DoubleMM/f_doubleMM.jl
+++ b/src/DoubleMM/f_doubleMM.jl
@@ -280,8 +280,8 @@ function HVI.gen_hybridproblem_synthetic(rng::AbstractRNG, prob::DoubleMMCase;
     θMs_true = int_θMs_sites(scale_centered_at(θMs_true0, θM, FloatType(0.1)))
     f = get_hybridproblem_PBmodel(prob; scenario, gdev = identity, use_all_sites = true)
     #xP = fill((; S1 = xP_S1, S2 = xP_S2), n_site)
-    int_xPn = ComponentArrayInterpreter(int_xP1, (n_site,))
-    xP = int_xPn(vcat(repeat(xP_S1, 1, n_site), repeat(xP_S2, 1, n_site)))
+    int_xP_sites = ComponentArrayInterpreter(int_xP1, (n_site,))
+    xP = int_xP_sites(vcat(repeat(xP_S1, 1, n_site), repeat(xP_S2, 1, n_site)))
     #xP[:S1,:]
     θP = par_templates.θP
     #θint = ComponentArrayInterpreter( (size(θMs_true,2),), CA.getaxes(vcat(θP, θMs_true[:,1])))

--- a/src/HybridProblem.jl
+++ b/src/HybridProblem.jl
@@ -1,21 +1,21 @@
 struct HybridProblem <: AbstractHybridProblem
-    θP::Any
-    θM::Any
+    θP::CA.ComponentVector
+    θM::CA.ComponentVector
     f_batch::Any
     f_allsites::Any
-    g::Any
-    ϕg::Any
-    ϕunc::Any
-    priors::Any
-    py::Any
-    transM::Any
-    transP::Any
-    cor_ends::Any # = (P=(1,),M=(1,))
-    train_dataloader::Any
+    g::AbstractModelApplicator
+    ϕg::Any # depends on framework
+    ϕunc::CA.ComponentVector
+    priors::AbstractDict
+    py::Any # any callable
+    transM::Stacked
+    transP::Stacked
+    cor_ends::@NamedTuple{P::Vector{Int}, M::Vector{Int}} # = (P=(1,),M=(1,))
+    train_dataloader::MLUtils.DataLoader
     n_covar::Int
     n_site::Int
     n_batch::Int
-    pbm_covars::NTuple
+    pbm_covars::NTuple{_N, Symbol} where _N
     #inner constructor to constrain the types
     function HybridProblem(
             θP::CA.ComponentVector, θM::CA.ComponentVector,
@@ -24,9 +24,9 @@ struct HybridProblem <: AbstractHybridProblem
             f_batch::Function, 
             f_allsites::Function,
             priors::AbstractDict,
-            py::Function,
-            transM::Union{Function, Bijectors.Transform},
-            transP::Union{Function, Bijectors.Transform},
+            py,
+            transM::Stacked,
+            transP::Stacked,
             # return a function that constructs the trainloader based on n_batch
             train_dataloader::MLUtils.DataLoader,
             n_covar::Int,

--- a/src/HybridProblem.jl
+++ b/src/HybridProblem.jl
@@ -93,33 +93,33 @@ function update(prob::HybridProblem;
         train_dataloader, n_covar, n_site, n_batch, cor_ends, pbm_covars)
 end
 
-function get_hybridproblem_par_templates(prob::HybridProblem; scenario::NTuple = ())
+function get_hybridproblem_par_templates(prob::HybridProblem; scenario = ())
     (; θP = prob.θP, θM = prob.θM)
 end
 
-function get_hybridproblem_ϕunc(prob::HybridProblem; scenario::NTuple = ())
+function get_hybridproblem_ϕunc(prob::HybridProblem; scenario = ())
     prob.ϕunc
 end
 
-function get_hybridproblem_neg_logden_obs(prob::HybridProblem; scenario::NTuple = ())
+function get_hybridproblem_neg_logden_obs(prob::HybridProblem; scenario = ())
     prob.py
 end
 
-function get_hybridproblem_transforms(prob::HybridProblem; scenario::NTuple = ())
+function get_hybridproblem_transforms(prob::HybridProblem; scenario = ())
     (; transP = prob.transP, transM = prob.transM)
 end
 
-# function get_hybridproblem_sizes(prob::HybridProblem; scenario::NTuple = ())
+# function get_hybridproblem_sizes(prob::HybridProblem; scenario = ())
 #     n_θM = length(prob.θM)
 #     n_θP = length(prob.θP)
 #     (; n_covar=prob.n_covar, n_batch=prob.n_batch, n_θM, n_θP)
 # end
 
-function get_hybridproblem_PBmodel(prob::HybridProblem; scenario::NTuple = (), use_all_sites=false)
+function get_hybridproblem_PBmodel(prob::HybridProblem; scenario = (), use_all_sites=false)
     use_all_sites ? prob.f_allsites : prob.f_batch
 end
 
-function get_hybridproblem_MLapplicator(prob::HybridProblem; scenario::NTuple = ())
+function get_hybridproblem_MLapplicator(prob::HybridProblem; scenario = ())
     prob.g, prob.ϕg
 end
 
@@ -144,6 +144,20 @@ function get_hybridproblem_priors(prob::HybridProblem; scenario = ())
     prob.priors
 end
 
-# function get_hybridproblem_float_type(prob::HybridProblem; scenario::NTuple = ()) 
+# function get_hybridproblem_float_type(prob::HybridProblem; scenario = ()) 
 #     eltype(prob.θM)
 # end
+
+"""
+Get the inverse-transformation of lower and upper quantiles of a Vector of Distributions.
+
+This can be used to get proper confidence intervals at unconstrained (log) ζ-scale
+for priors on normal θ-scale for constructing a NormalScalingModelApplicator.
+"""
+function get_quantile_transformed(priors::AbstractVector{<:Distribution}, trans; 
+    q95 = (0.05, 0.95))
+    θq = ([quantile(d, q) for d in priors] for q in q95)
+    lowers, uppers = inverse(trans).(θq)
+end
+
+

--- a/src/HybridSolver.jl
+++ b/src/HybridSolver.jl
@@ -7,18 +7,20 @@ end
 HybridPointSolver(; alg) = HybridPointSolver(alg)
 
 function CommonSolve.solve(prob::AbstractHybridProblem, solver::HybridPointSolver;
-        scenario, rng = Random.default_rng(), 
-        gdev = :use_gpu ∈ scenario ? gpu_device() : identity, 
-        cdev = gdev isa MLDataDevices.AbstractGPUDevice ? cpu_device() : identity,
-        kwargs...)
+    scenario, rng=Random.default_rng(),
+    gdev=:use_gpu ∈ scenario ? gpu_device() : identity,
+    cdev=gdev isa MLDataDevices.AbstractGPUDevice ? cpu_device() : identity,
+    is_inferred::Val{is_infer} = Val(false),
+    kwargs...
+) where is_infer
     par_templates = get_hybridproblem_par_templates(prob; scenario)
     g, ϕg0 = get_hybridproblem_MLapplicator(prob; scenario)
     FT = get_hybridproblem_float_type(prob; scenario)
     (; transP, transM) = get_hybridproblem_transforms(prob; scenario)
     intϕ = ComponentArrayInterpreter(CA.ComponentVector(
-        ϕg = 1:length(ϕg0), ϕP = par_templates.θP))
+        ϕg=1:length(ϕg0), ϕP=par_templates.θP))
     #ϕ0_cpu = vcat(ϕg0, par_templates.θP .* FT(0.9))  # slightly disturb θP_true
-    ϕ0_cpu = vcat(ϕg0, apply_preserve_axes(inverse(transP),par_templates.θP))
+    ϕ0_cpu = vcat(ϕg0, apply_preserve_axes(inverse(transP), par_templates.θP))
     train_loader = get_hybridproblem_train_dataloader(prob; scenario)
     if gdev isa MLDataDevices.AbstractGPUDevice
         ϕ0_dev = gdev(ϕ0_cpu)
@@ -29,27 +31,33 @@ function CommonSolve.solve(prob::AbstractHybridProblem, solver::HybridPointSolve
         g_dev = g
         train_loader_dev = train_loader
     end
-    f = get_hybridproblem_PBmodel(prob; scenario, use_all_sites = false)
+    f = get_hybridproblem_PBmodel(prob; scenario, use_all_sites=false)
     y_global_o = FT[] # TODO
     pbm_covars = get_hybridproblem_pbmpar_covars(prob; scenario)
+    n_site, n_batch = get_hybridproblem_n_site_and_batch(prob; scenario)
     #intP = ComponentArrayInterpreter(par_templates.θP)
-    loss_gf = get_loss_gf(g_dev, transM, transP, f, y_global_o, intϕ; cdev, pbm_covars)
+    loss_gf = get_loss_gf(g_dev, transM, transP, f, y_global_o, intϕ;
+        cdev, pbm_covars, n_site_batch=n_batch)
     # call loss function once
-    l1 = loss_gf(ϕ0_dev, first(train_loader_dev)...)[1]
+    l1 = is_infer ? 
+        Test.@inferred(loss_gf(ϕ0_dev, first(train_loader_dev)...))[1] : 
+        # using ShareAdd; @usingany Cthulhu
+        # @descend_code_warntype loss_gf(ϕ0_dev, first(train_loader_dev)...)
+        loss_gf(ϕ0_dev, first(train_loader_dev)...)[1]
     # and gradient
     # xMg, xP, y_o, y_unc = first(train_loader_dev)
     # gr1 = Zygote.gradient(
     #             p -> loss_gf(p, xMg, xP, y_o, y_unc)[1],
     #             ϕ0_dev)
-165    # Zygote.gradient(ϕ0_dev -> loss_gf(ϕ0_dev, data1...)[1], ϕ0_dev)
+    # Zygote.gradient(ϕ0_dev -> loss_gf(ϕ0_dev, data1...)[1], ϕ0_dev)
     optf = Optimization.OptimizationFunction((ϕ, data) -> loss_gf(ϕ, data...)[1],
         Optimization.AutoZygote())
     optprob = OptimizationProblem(optf, CA.getdata(ϕ0_dev), train_loader_dev)
     res = Optimization.solve(optprob, solver.alg; kwargs...)
     ϕ = intϕ(res.u)
     θP = cpu_ca(apply_preserve_axes(transP, cpu_ca(ϕ).ϕP))
-    probo = update(prob; ϕg = cpu_ca(ϕ).ϕg, θP)
-    (; ϕ, resopt = res, probo)
+    probo = update(prob; ϕg=cpu_ca(ϕ).ϕg, θP)
+    (; ϕ, resopt=res, probo)
 end
 
 struct HybridPosteriorSolver{A} <: AbstractHybridSolver
@@ -57,22 +65,24 @@ struct HybridPosteriorSolver{A} <: AbstractHybridSolver
     n_MC::Int
     n_MC_cap::Int
 end
-function HybridPosteriorSolver(; alg, n_MC = 12, n_MC_cap = n_MC)
+function HybridPosteriorSolver(; alg, n_MC=12, n_MC_cap=n_MC)
     HybridPosteriorSolver(alg, n_MC, n_MC_cap)
 end
 function update(solver::HybridPosteriorSolver;
-        alg = solver.alg,
-        n_MC = solver.n_MC,
-        n_MC_cap = n_MC)
+    alg=solver.alg,
+    n_MC=solver.n_MC,
+    n_MC_cap=n_MC)
     HybridPosteriorSolver(alg, n_MC, n_MC_cap)
 end
 
 function CommonSolve.solve(prob::AbstractHybridProblem, solver::HybridPosteriorSolver;
-        scenario, rng = Random.default_rng(), 
-        gdev = :use_gpu ∈ scenario ? gpu_device() : identity, 
-        cdev = gdev isa MLDataDevices.AbstractGPUDevice ? cpu_device() : identity,
-        θmean_quant = 0.0,
-        kwargs...)
+    scenario::Val{scen}, rng=Random.default_rng(),
+    gdev=:use_gpu ∈ _val_value(scenario) ? gpu_device() : identity,
+    cdev=gdev isa MLDataDevices.AbstractGPUDevice ? cpu_device() : identity,
+    θmean_quant=0.0,
+    is_inferred::Val{is_infer} = Val(false),
+    kwargs...
+) where {scen, is_infer}
     par_templates = get_hybridproblem_par_templates(prob; scenario)
     (; θP, θM) = par_templates
     cor_ends = get_hybridproblem_cor_ends(prob; scenario)
@@ -81,8 +91,13 @@ function CommonSolve.solve(prob::AbstractHybridProblem, solver::HybridPosteriorS
     (; transP, transM) = get_hybridproblem_transforms(prob; scenario)
     pbm_covars = get_hybridproblem_pbmpar_covars(prob; scenario)
     n_site, n_batch = get_hybridproblem_n_site_and_batch(prob; scenario)
+    hpints = HybridProblemInterpreters(prob; scenario)
     (; ϕ, transPMs_batch, interpreters, get_transPMs, get_ca_int_PMs) = init_hybrid_params(
-    θP, θM, cor_ends, ϕg0, n_batch; transP, transM, ϕunc0)
+        θP, θM, cor_ends, ϕg0, hpints; transP, transM, ϕunc0)
+    int_unc = interpreters.unc
+    int_μP_ϕg_unc = interpreters.μP_ϕg_unc
+    transMs = StackedArray(transM, n_batch)
+    #
     train_loader = get_hybridproblem_train_dataloader(prob; scenario)
     if gdev isa MLDataDevices.AbstractGPUDevice
         ϕ0_dev = gdev(ϕ)
@@ -93,25 +108,31 @@ function CommonSolve.solve(prob::AbstractHybridProblem, solver::HybridPosteriorS
         g_dev = g
         train_loader_dev = train_loader
     end
-    f = get_hybridproblem_PBmodel(prob; scenario, use_all_sites = false)
+    f = get_hybridproblem_PBmodel(prob; scenario, use_all_sites=false)
     py = get_hybridproblem_neg_logden_obs(prob; scenario)
-    priors_θ_mean = construct_priors_θ_mean(
+
+    priors_θP_mean, priors_θMs_mean = construct_priors_θ_mean(
         prob, ϕ0_dev.ϕg, keys(θM), θP, θmean_quant, g_dev, transM, transP;
         scenario, get_ca_int_PMs, gdev, cdev, pbm_covars)
     y_global_o = Float32[] # TODO
+
     loss_elbo = get_loss_elbo(
-        g_dev, transPMs_batch, f, py, y_global_o, interpreters;
-        solver.n_MC, solver.n_MC_cap, cor_ends, priors_θ_mean, cdev, pbm_covars, θP)
+        g_dev, transP, transMs, f, py, y_global_o;
+        solver.n_MC, solver.n_MC_cap, cor_ends, priors_θP_mean, priors_θMs_mean, cdev,
+        pbm_covars, θP, int_unc, int_μP_ϕg_unc)
     # test loss function once
-    l0 = loss_elbo(ϕ0_dev, rng, first(train_loader_dev)...)
+    #Main.@infiltrate_main
+    l0 = is_infer ? 
+        (Test.@inferred loss_elbo(ϕ0_dev, rng, first(train_loader_dev)...)) :
+        loss_elbo(ϕ0_dev, rng, first(train_loader_dev)...)
     optf = Optimization.OptimizationFunction((ϕ, data) -> loss_elbo(ϕ, rng, data...)[1],
         Optimization.AutoZygote())
     optprob = OptimizationProblem(optf, CA.getdata(ϕ0_dev), train_loader_dev)
     res = Optimization.solve(optprob, solver.alg; kwargs...)
     ϕc = interpreters.μP_ϕg_unc(res.u)
     θP = cpu_ca(apply_preserve_axes(transP, ϕc.μP))
-    probo = update(prob; ϕg = cpu_ca(ϕc).ϕg, θP = θP, ϕunc = cpu_ca(ϕc).unc);
-    (; ϕ = ϕc, θP, resopt = res, interpreters, probo)
+    probo = update(prob; ϕg=cpu_ca(ϕc).ϕg, θP=θP, ϕunc=cpu_ca(ϕc).unc)
+    (; ϕ=ϕc, θP, resopt=res, interpreters, probo)
 end
 
 function fit_narrow_normal(θi, prior, θmean_quant)
@@ -138,20 +159,27 @@ The loss function takes in addition to ϕ, data that changes with minibatch
 - `xP`: drivers for the processmodel: Iterator of size n_site
 - `y_o`, `y_unc`: matrix of observations and uncertainties, sites in columns
 """
-function get_loss_elbo(g, transP, transM, f, py, y_o_global, interpreters;
-        n_MC, n_MC_cap = n_MC, cor_ends, priors_θ_mean, cdev, pbm_covars, θP,
-        )
-    let g = g, transP = transP, transM = transM, f = f, py = py, y_o_global = y_o_global, n_MC = n_MC,
-        cor_ends = cor_ends, interpreters = map(get_concrete, interpreters),
-        priors_θ_mean = priors_θ_mean, cdev = cdev, 
+function get_loss_elbo(g, transP, transMs, f, py, y_o_global;
+    n_MC, n_MC_mean = max(n_MC,20), n_MC_cap=n_MC, 
+    cor_ends, priors_θP_mean, priors_θMs_mean, cdev, pbm_covars, θP,
+    int_unc, int_μP_ϕg_unc,
+)
+    let g = g, transP = transP, transMs = transMs, f = f, py = py, y_o_global = y_o_global, 
+        n_MC = n_MC, n_MC_cap = n_MC_cap, n_MC_mean = n_MC_mean,
+        cor_ends = cor_ends,
+        int_unc = get_concrete(int_unc), int_μP_ϕg_unc = get_concrete(int_μP_ϕg_unc),
+        priors_θP_mean = priors_θP_mean, priors_θMs_mean = priors_θMs_mean, cdev = cdev,
         pbm_covar_indices = get_pbm_covar_indices(θP, pbm_covars),
-        transform_tools = setup_transform_ζ(transP, transM, interpreters.PMs)
+        trans_mP=StackedArray(transP, n_MC_mean), 
+        trans_mMs=StackedArray(transMs.stacked, n_MC_mean)
 
         function loss_elbo(ϕ, rng, xM, xP, y_o, y_unc, i_sites)
             neg_elbo_gtf(
                 rng, ϕ, g, f, py, xM, xP, y_o, y_unc, i_sites;
-                int_unc = interpreters.int_unc, int_μP_ϕg_unc = interpreters.int_μP_ϕg_unc, 
-                n_MC, n_MC_cap, cor_ends, priors_θ_mean, cdev, pbm_covar_indices)
+                int_unc, int_μP_ϕg_unc,
+                n_MC, n_MC_cap, n_MC_mean, cor_ends, priors_θP_mean, priors_θMs_mean,
+                cdev, pbm_covar_indices, transP, transMs, trans_mP, trans_mMs,
+            )
         end
     end
 end
@@ -161,11 +189,11 @@ Compute the components of the elbo for given initial conditions of the problems
 for the first batch of the trainloader.
 """
 function compute_elbo_components(
-        prob::AbstractHybridProblem, solver::HybridPosteriorSolver;
-        scenario, rng = Random.default_rng(), gdev = gpu_device(),
-        θmean_quant = 0.0,
-        use_all_sites = false,
-        kwargs...)
+    prob::AbstractHybridProblem, solver::HybridPosteriorSolver;
+    scenario, rng=Random.default_rng(), gdev=gpu_device(),
+    θmean_quant=0.0,
+    use_all_sites=false,
+    kwargs...)
     n_site, n_batch = get_hybridproblem_n_site_and_batch(prob; scenario)
     par_templates = get_hybridproblem_par_templates(prob; scenario)
     (; θP, θM) = par_templates
@@ -174,7 +202,7 @@ function compute_elbo_components(
     ϕunc0 = get_hybridproblem_ϕunc(prob; scenario)
     (; transP, transM) = get_hybridproblem_transforms(prob; scenario)
     (; ϕ, transPMs_batch, interpreters, get_transPMs, get_ca_int_PMs) = init_hybrid_params(
-    θP, θM, cor_ends, ϕg0, n_batch; transP, transM, ϕunc0)
+        θP, θM, cor_ends, ϕg0, n_batch; transP, transM, ϕunc0)
     train_loader = get_hybridproblem_train_dataloader(prob; scenario)
     if gdev isa MLDataDevices.AbstractGPUDevice
         ϕ0_dev = gdev(ϕ)
@@ -202,21 +230,24 @@ In order to let mean of θ stay close to initial point parameter estimates
 construct a prior on mean θ to a Normal around initial prediction.
 """
 function construct_priors_θ_mean(prob, ϕg, keysθM, θP, θmean_quant, g_dev, transM, transP;
-        scenario, get_ca_int_PMs, gdev, cdev, pbm_covars)
-    iszero(θmean_quant) ? [] :
+    scenario::Val{scen}, get_ca_int_PMs, gdev, cdev, pbm_covars) where {scen}
+    iszero(θmean_quant) ? ([],[]) :
     begin
         n_site, n_batch = get_hybridproblem_n_site_and_batch(prob; scenario)
         # all_loader = MLUtils.DataLoader(
         #     get_hybridproblem_train_dataloader(prob; scenario).data, batchsize = n_site)
         # xM_all = first(all_loader)[1]
-        is_gpu = :use_gpu ∈ scenario
+        is_gpu = :use_gpu ∈ scen
         xM_all_cpu = get_hybridproblem_train_dataloader(prob; scenario).data[1]
         xM_all = is_gpu ? gdev(xM_all_cpu) : xM_all_cpu
         ζP = apply_preserve_axes(inverse(transP), θP)
         pbm_covar_indices = get_pbm_covar_indices(θP, pbm_covars)
-        xMP_all = _append_each_covars(xM_all, CA.getdata(ζP), pbm_covar_indices) 
-        #Main.@infiltrate_main
-        θMs = gtrans(g_dev, transM, xMP_all, CA.getdata(ϕg); cdev = cpu_device())
+        xMP_all = _append_each_covars(xM_all, CA.getdata(ζP), pbm_covar_indices)
+        transMs = StackedArray(transM, n_site)
+        # ζMs = g_dev(xMP_all, CA.getdata(ϕg))'  # transpose to par-last for StackedArray
+        # ζMs_cpu = cdev(ζMs)
+        # θMs = transMs(ζMs_cpu)
+        θMs = gtrans(g_dev, transMs, xMP_all, CA.getdata(ϕg); cdev=cpu_device())
         priors_dict = get_hybridproblem_priors(prob; scenario)
         priorsP = [priors_dict[k] for k in keys(θP)]
         priors_θP_mean = map(priorsP, θP) do priorsP, θPi
@@ -225,12 +256,13 @@ function construct_priors_θ_mean(prob, ϕg, keysθM, θP, θmean_quant, g_dev, 
         priorsM = [priors_dict[k] for k in keysθM]
         i_par = 1
         i_site = 1
-        priors_θMs_mean = map(Iterators.product(axes(θMs)...)) do (i_par, i_site)
+        priors_θMs_mean = map(Iterators.product(axes(θMs)...)) do (i_site, i_par)
             #@show i_par, i_site
-            fit_narrow_normal(θMs[i_par, i_site], priorsM[i_par], θmean_quant)
+            fit_narrow_normal(θMs[i_site, i_par], priorsM[i_par], θmean_quant)
         end
-        # concatenate to a flat vector
-        int_n_site = get_ca_int_PMs(n_site)
-        int_n_site(vcat(priors_θP_mean, vec(priors_θMs_mean)))
+        # # concatenate to a flat vector
+        # int_n_site = get_ca_int_PMs(n_site)
+        # int_n_site(vcat(priors_θP_mean, vec(priors_θMs_mean)))
+        priors_θP_mean, priors_θMs_mean
     end
 end

--- a/src/HybridSolver.jl
+++ b/src/HybridSolver.jl
@@ -138,17 +138,19 @@ The loss function takes in addition to ϕ, data that changes with minibatch
 - `xP`: drivers for the processmodel: Iterator of size n_site
 - `y_o`, `y_unc`: matrix of observations and uncertainties, sites in columns
 """
-function get_loss_elbo(g, transPMs, f, py, y_o_global, interpreters;
+function get_loss_elbo(g, transP, transM, f, py, y_o_global, interpreters;
         n_MC, n_MC_cap = n_MC, cor_ends, priors_θ_mean, cdev, pbm_covars, θP,
         )
-    let g = g, transPMs = transPMs, f = f, py = py, y_o_global = y_o_global, n_MC = n_MC,
+    let g = g, transP = transP, transM = transM, f = f, py = py, y_o_global = y_o_global, n_MC = n_MC,
         cor_ends = cor_ends, interpreters = map(get_concrete, interpreters),
         priors_θ_mean = priors_θ_mean, cdev = cdev, 
-        pbm_covar_indices = get_pbm_covar_indices(θP, pbm_covars)
+        pbm_covar_indices = get_pbm_covar_indices(θP, pbm_covars),
+        transform_tools = setup_transform_ζ(transP, transM, interpreters.PMs)
 
         function loss_elbo(ϕ, rng, xM, xP, y_o, y_unc, i_sites)
             neg_elbo_gtf(
-                rng, ϕ, g, transPMs, f, py, xM, xP, y_o, y_unc, i_sites, interpreters;
+                rng, ϕ, g, f, py, xM, xP, y_o, y_unc, i_sites, interpreters, 
+                transform_tools;
                 n_MC, n_MC_cap, cor_ends, priors_θ_mean, cdev, pbm_covar_indices)
         end
     end

--- a/src/HybridSolver.jl
+++ b/src/HybridSolver.jl
@@ -8,7 +8,7 @@ HybridPointSolver(; alg) = HybridPointSolver(alg)
 
 function CommonSolve.solve(prob::AbstractHybridProblem, solver::HybridPointSolver;
     scenario, rng=Random.default_rng(),
-    gdev=:use_gpu ∈ scenario ? gpu_device() : identity,
+    gdev=:use_gpu ∈ _val_value(scenario) ? gpu_device() : identity,
     cdev=gdev isa MLDataDevices.AbstractGPUDevice ? cpu_device() : identity,
     is_inferred::Val{is_infer} = Val(false),
     kwargs...
@@ -125,7 +125,7 @@ function CommonSolve.solve(prob::AbstractHybridProblem, solver::HybridPosteriorS
     l0 = is_infer ? 
         (Test.@inferred loss_elbo(ϕ0_dev, rng, first(train_loader_dev)...)) :
         loss_elbo(ϕ0_dev, rng, first(train_loader_dev)...)
-    optf = Optimization.OptimizationFunction((ϕ, data) -> loss_elbo(ϕ, rng, data...)[1],
+    optf = Optimization.OptimizationFunction((ϕ, data) -> first(loss_elbo(ϕ, rng, data...)),
         Optimization.AutoZygote())
     optprob = OptimizationProblem(optf, CA.getdata(ϕ0_dev), train_loader_dev)
     res = Optimization.solve(optprob, solver.alg; kwargs...)

--- a/src/HybridSolver.jl
+++ b/src/HybridSolver.jl
@@ -149,8 +149,8 @@ function get_loss_elbo(g, transP, transM, f, py, y_o_global, interpreters;
 
         function loss_elbo(ϕ, rng, xM, xP, y_o, y_unc, i_sites)
             neg_elbo_gtf(
-                rng, ϕ, g, f, py, xM, xP, y_o, y_unc, i_sites, interpreters, 
-                transform_tools;
+                rng, ϕ, g, f, py, xM, xP, y_o, y_unc, i_sites;
+                int_unc = interpreters.int_unc, int_μP_ϕg_unc = interpreters.int_μP_ϕg_unc, 
                 n_MC, n_MC_cap, cor_ends, priors_θ_mean, cdev, pbm_covar_indices)
         end
     end

--- a/src/HybridVariationalInference.jl
+++ b/src/HybridVariationalInference.jl
@@ -84,7 +84,7 @@ include("logden_normal.jl")
 export get_ca_starts, get_ca_ends, get_cor_count
 include("cholesky.jl")
 
-export neg_elbo_gtf, predict_gf
+export neg_elbo_gtf, predict_hvi
 include("elbo.jl")
 
 export init_hybrid_params, init_hybrid_ϕunc

--- a/src/HybridVariationalInference.jl
+++ b/src/HybridVariationalInference.jl
@@ -26,7 +26,7 @@ export extend_stacked_nrow
 include("bijectors_utils.jl") 
 
 export AbstractComponentArrayInterpreter, ComponentArrayInterpreter, flatten1 
-export get_concrete, get_positions, stack_ca_int
+export get_concrete, get_positions, stack_ca_int, compose_interpreters
 include("ComponentArrayInterpreter.jl")
 
 export AbstractModelApplicator, construct_ChainsApplicator

--- a/src/HybridVariationalInference.jl
+++ b/src/HybridVariationalInference.jl
@@ -20,6 +20,7 @@ using Distributions, DistributionFits
 using StaticArrays: StaticArrays as SA
 using Functors
 
+export extend_stacked_nrow
 #export Exp
 include("bijectors_utils.jl") 
 

--- a/src/HybridVariationalInference.jl
+++ b/src/HybridVariationalInference.jl
@@ -21,7 +21,7 @@ using StaticArrays: StaticArrays as SA
 using Functors
 using Test: Test # @inferred
 
-export extend_stacked_nrow
+export extend_stacked_nrow, StackedArray
 #export Exp
 include("bijectors_utils.jl") 
 

--- a/src/HybridVariationalInference.jl
+++ b/src/HybridVariationalInference.jl
@@ -63,9 +63,10 @@ export AbstractHybridProblemInterpreters, HybridProblemInterpreters,
 include("hybridprobleminterpreters.jl")
 
 export HybridProblem
+export get_quantile_transformed
 include("HybridProblem.jl")
 
-export applyf, gf, get_loss_gf
+export map_f_each_site, gf, get_loss_gf
 include("gf.jl")
 
 export compute_correlated_covars, scale_centered_at

--- a/src/HybridVariationalInference.jl
+++ b/src/HybridVariationalInference.jl
@@ -19,12 +19,14 @@ using Optimization
 using Distributions, DistributionFits
 using StaticArrays: StaticArrays as SA
 using Functors
+using Test: Test # @inferred
 
 export extend_stacked_nrow
 #export Exp
 include("bijectors_utils.jl") 
 
-export ComponentArrayInterpreter, flatten1, get_concrete, get_positions
+export AbstractComponentArrayInterpreter, ComponentArrayInterpreter, flatten1 
+export get_concrete, get_positions, stack_ca_int
 include("ComponentArrayInterpreter.jl")
 
 export AbstractModelApplicator, construct_ChainsApplicator

--- a/src/HybridVariationalInference.jl
+++ b/src/HybridVariationalInference.jl
@@ -55,6 +55,12 @@ export AbstractHybridProblem, get_hybridproblem_MLapplicator, get_hybridproblem_
        setup_PBMpar_interpreter
 include("AbstractHybridProblem.jl")
 
+export AbstractHybridProblemInterpreters, HybridProblemInterpreters, 
+       get_int_P, get_int_M, 
+       get_int_Ms_batch, get_int_Ms_site, get_int_Mst_batch, get_int_Mst_site,
+       get_int_PMs_batch, get_int_PMs_site, get_int_PMst_batch, get_int_PMst_site
+include("hybridprobleminterpreters.jl")
+
 export HybridProblem
 include("HybridProblem.jl")
 

--- a/src/HybridVariationalInference.jl
+++ b/src/HybridVariationalInference.jl
@@ -23,10 +23,11 @@ using Test: Test # @inferred
 
 export extend_stacked_nrow, StackedArray
 #export Exp
-include("bijectors_utils.jl") 
+include("bijectors_utils.jl")
 
-export AbstractComponentArrayInterpreter, ComponentArrayInterpreter, flatten1 
-export get_concrete, get_positions, stack_ca_int, compose_interpreters
+export AbstractComponentArrayInterpreter, ComponentArrayInterpreter,
+       StaticComponentArrayInterpreter
+export flatten1, get_concrete, get_positions, stack_ca_int, compose_interpreters
 include("ComponentArrayInterpreter.jl")
 
 export AbstractModelApplicator, construct_ChainsApplicator
@@ -55,8 +56,8 @@ export AbstractHybridProblem, get_hybridproblem_MLapplicator, get_hybridproblem_
        setup_PBMpar_interpreter
 include("AbstractHybridProblem.jl")
 
-export AbstractHybridProblemInterpreters, HybridProblemInterpreters, 
-       get_int_P, get_int_M, 
+export AbstractHybridProblemInterpreters, HybridProblemInterpreters,
+       get_int_P, get_int_M,
        get_int_Ms_batch, get_int_Ms_site, get_int_Mst_batch, get_int_Mst_site,
        get_int_PMs_batch, get_int_PMs_site, get_int_PMst_batch, get_int_PMst_site
 include("hybridprobleminterpreters.jl")

--- a/src/ModelApplicator.jl
+++ b/src/ModelApplicator.jl
@@ -131,7 +131,7 @@ Fit a Normal distribution to iterators lower and upper.
 If `repeat_inner` is given, each fitted distribution is repeated as many times.
 """
 function NormalScalingModelApplicator(
-    app::AbstractModelApplicator, lowers, uppers, ET::Type; repeat_inner::Integer = 1) 
+    app::AbstractModelApplicator, lowers::AbstractVector{<:Number}, uppers, ET::Type; repeat_inner::Integer = 1) 
     pars = map(lowers, uppers) do lower, upper
         dζ = fit(Normal, @qp_l(lower), @qp_u(upper))
         params(dζ)
@@ -140,15 +140,6 @@ function NormalScalingModelApplicator(
     μ = repeat(collect(ET, first.(pars)); inner=(repeat_inner,))  
     σ = repeat(collect(ET, last.(pars)); inner=(repeat_inner,))
     NormalScalingModelApplicator(app, μ, σ)
-end
-
-"""
-Get the inverse-transformation of lower and upper quantiles of a Vector of Distributions.
-"""
-function get_quantile_transformed(priors::AbstractVector{<:Distribution}, trans; 
-    q95 = (0.05, 0.95))
-    θq = ([quantile(d, q) for d in priors] for q in q95)
-    lower, upper = inverse(trans).(θq)
 end
 
 function apply_model(app::NormalScalingModelApplicator, x, ϕ)

--- a/src/ModelApplicator.jl
+++ b/src/ModelApplicator.jl
@@ -52,11 +52,13 @@ end
 """
     construct_3layer_MLApplicator(
         rng::AbstractRNG, prob::HVI.AbstractHybridProblem, <ml_engine>;
-        scenario::NTuple = ())
+        scenario::Val{scen}) where scen
 
 Construct a machine learning model for given Proglem and machine learning engine.
 Implemented for machine learning extensions, such as Flux or SimpleChains.
 `ml_engine` usually is of type `Val{Symbol}`, e.g. Val(:Flux). See `select_ml_engine`.       
+
+Scenario is a value-type of `NTuple{_,Symbol}`.
 """
 function construct_3layer_MLApplicator end
 
@@ -68,10 +70,10 @@ Returns a value type `Val{:Symbol}` to dispatch on the machine learning engine t
 - `:use_Lux ∈ scenario -> Val(:Lux)`
 - `:use_Flux ∈ scenario -> Val(:Flux)`
 """
-function select_ml_engine(;scenario)
-    if :use_Lux ∈ scenario
+function select_ml_engine(; scenario::Val{scen}) where scen
+    if :use_Lux ∈ scen
         return Val(:Lux)
-    elseif :use_Flux ∈ scenario
+    elseif :use_Flux ∈ scen
         return Val(:Flux)
     else
         # default
@@ -104,14 +106,15 @@ end
     NormalScalingModelApplicator(app, priors, transM)
 
 Wrapper around AbstractModelApplicator that transforms each output 
-(assumed in [0..1], usch as output of logistic activation function)
+(assumed in [0..1], such as output of logistic activation function)
 to a quantile of a Normal distribution. 
 
 Length of μ, σ must correspond to the number of outputs of the wrapped ModelApplicator.
 
-This helps to keep raw ML-predictions (in confidence bounds) and weights in a similar magnitude.
-Compared to specifying bounds, this allows for the possibility (although harder to converge)
-far beyond the confidence bounds.
+This helps to keep raw ML-predictions (in confidence bounds) and weights in a 
+similar magnitude.
+Compared to specifying bounds, this allows for the possibility 
+(although harder to converge) far beyond the confidence bounds.
 
 The second constructor fits a normal distribution of the inverse-transformed 5% and 95%
 quantiles of prior distributions.
@@ -123,20 +126,29 @@ struct NormalScalingModelApplicator{VF,A} <: AbstractModelApplicator
 end
 @functor NormalScalingModelApplicator
 
+"""
+Fit a Normal distribution to iterators lower and upper. 
+If `repeat_inner` is given, each fitted distribution is repeated as many times.
+"""
 function NormalScalingModelApplicator(
-    app::AbstractModelApplicator, priors::AbstractVector{<:Distribution}, transM, ET::Type)
-    # need to apply transform to entire vectors each of lowers and uppers
-    θq = ([quantile(d, q) for d in priors] for q in (0.05, 0.95))
-    ζlower, ζupper = inverse(transM).(θq)
-    #ipar = first(axes(ζlower,1))
-    pars = map(axes(ζlower,1)) do ipar
-        dζ = fit(Normal, @qp_l(ζlower[ipar]), @qp_u(ζupper[ipar]))
+    app::AbstractModelApplicator, lowers, uppers, ET::Type; repeat_inner::Integer = 1) 
+    pars = map(lowers, uppers) do lower, upper
+        dζ = fit(Normal, @qp_l(lower), @qp_u(upper))
         params(dζ)
     end
     # use collect to make it an array that works with gpu
-    μ = collect(ET, first.(pars))  
-    σ = collect(ET, last.(pars))
+    μ = repeat(collect(ET, first.(pars)); inner=(repeat_inner,))  
+    σ = repeat(collect(ET, last.(pars)); inner=(repeat_inner,))
     NormalScalingModelApplicator(app, μ, σ)
+end
+
+"""
+Get the inverse-transformation of lower and upper quantiles of a Vector of Distributions.
+"""
+function get_quantile_transformed(priors::AbstractVector{<:Distribution}, trans; 
+    q95 = (0.05, 0.95))
+    θq = ([quantile(d, q) for d in priors] for q in q95)
+    lower, upper = inverse(trans).(θq)
 end
 
 function apply_model(app::NormalScalingModelApplicator, x, ϕ)

--- a/src/bijectors_utils.jl
+++ b/src/bijectors_utils.jl
@@ -19,3 +19,33 @@ end
 
 
 Bijectors.is_monotonically_increasing(::Exp) = true
+
+
+"""
+    extend_stacked_nrow(b::Stacked, nrow::Integer)
+
+Create a Stacked bijectors that transforms nrow times the elements
+of the original Stacked bijector.
+
+# Example
+```
+X = reduce(hcat, ([x + y for x in 0:4 ] for y in 0:10:30))
+b1 = CP.Exp()
+b2 = identity
+b = Stacked((b1,b2), (1:1,2:4))
+bs = extend_stacked_nrow(b, size(X,1))
+Xt = reshape(bs(vec(X)), size(X))
+@test Xt[:,1] == b1(X[:,1])
+@test Xt[:,2:4] == b2(X[:,2:4])
+```
+"""
+function extend_stacked_nrow(b::Stacked, nrow::Integer)
+    onet = one(eltype(first(b.ranges_in)))
+    endpos = last.(b.ranges_in) .* nrow 
+    startpos2 = (endpos[1:(end-1)] .+ onet)
+    ranges = ntuple(length(endpos)) do i
+        startpos = i == 1 ? onet : startpos2[i-1]
+        startpos:endpos[i]
+    end
+    bs = Stacked(b.bs, ranges)
+end

--- a/src/elbo.jl
+++ b/src/elbo.jl
@@ -245,7 +245,8 @@ Steps:
 `ζsP` and `ζsMs` are shaped according to the output of `generate_ζ`.
 Results are of shape `(n_obs x n_site_pred x n_MC)`.
 """
-function apply_f_trans(ζsP::AbstractMatrix, ζsMs::AbstractArray, f, xP; transP, transM::Stacked,
+function apply_f_trans(ζsP::AbstractMatrix, ζsMs::AbstractArray, f, xP; 
+    transP, transM::Stacked,
     trans_mP=StackedArray(transP, size(ζsP, 2)),
     trans_mMs=StackedArray(transM, size(ζsMs, 1) * size(ζsMs, 3))
 )

--- a/src/elbo.jl
+++ b/src/elbo.jl
@@ -164,7 +164,7 @@ Returns an NamedTuple `(; y, θsP, θsMs, entropy_ζ)` with entries
   that are kept constant across sites.
 - `θsMs`: ComponentArray `(n_site, n_θM, n_sample_pred)` of PBM model parameters
   that vary by site.
-- `entropy_ζ`: The entroy of the log-determinant of the transformation of 
+- `entropy_ζ`: The entropy of the log-determinant of the transformation of 
   the set of model parameters, which is involved in uncertainty quantification.
 """
 function predict_hvi(rng, prob::AbstractHybridProblem; scenario, kwargs...)

--- a/src/elbo.jl
+++ b/src/elbo.jl
@@ -346,12 +346,12 @@ function sample_ζ_norm0(rng::Random.AbstractRNG, ζP::AbstractVector, ζMs::Abs
         args...; n_MC, cor_ends, int_unc)
     n_θP, n_θMs = length(ζP), length(ζMs)
     urand = _create_random(rng, CA.getdata(ζP), n_θP + n_θMs, n_MC)
-    sample_ζ_norm0(urand, ζP, ζMs, args...; cor_ends, int_unc = get_concrete(int_unc))
+    sample_ζ_norm0(urand, CA.getdata(ζP), CA.getdata(ζMs), args...; cor_ends, int_unc = get_concrete(int_unc))
 end
 
-function sample_ζ_norm0(urand::AbstractMatrix, ζP::AbstractVector{T}, ζMs::AbstractMatrix,
+function sample_ζ_norm0(urand::AbstractMatrix, ζP::TP, ζMs::TM,
         ϕunc::AbstractVector; int_unc = get_concrete(ComponentArrayInterpreter(ϕunc)), cor_ends
-) where {T}
+) where {T, TP <: AbstractVector{T}, TM <:AbstractMatrix{T}}
     ϕuncc = int_unc(CA.getdata(ϕunc))
     n_θP, n_θMs, (n_θM, n_batch) = length(ζP), length(ζMs), size(ζMs)
     # do not create a UpperTriangular Matrix of an AbstractGÜUArray in transformU_cholesky1

--- a/src/hybridprobleminterpreters.jl
+++ b/src/hybridprobleminterpreters.jl
@@ -42,22 +42,22 @@ end
 
 function get_int_PMs_batch(ints::HPInts{AXP,AXM, NS, NB}) where {AXP,AXM,NS,NB}
     AX_MS = CA.getaxes(get_int_Ms_batch(ints))
-    AX_PMs = combine_axes((;P=AXP, Ms=AX_MS))
+    AX_PMs = compose_axes((;P=AXP, Ms=AX_MS))
     StaticComponentArrayInterpreter{(AX_PMs,)}()
 end
 function get_int_PMst_batch(ints::HPInts{AXP,AXM, NS, NB}) where {AXP,AXM,NS,NB}
     AX_MS = CA.getaxes(get_int_Mst_batch(ints)) # note the t after Ms
-    AX_PMs = combine_axes((;P=AXP, Ms=AX_MS))
+    AX_PMs = compose_axes((;P=AXP, Ms=AX_MS))
     StaticComponentArrayInterpreter{(AX_PMs,)}()
 end
 function get_int_PMs_site(ints::HPInts{AXP,AXM, NS, NB}) where {AXP,AXM,NS,NB}
     AX_MS = CA.getaxes(get_int_Ms_site(ints))
-    AX_PMs = combine_axes((;P=AXP, Ms=AX_MS))
+    AX_PMs = compose_axes((;P=AXP, Ms=AX_MS))
     StaticComponentArrayInterpreter{(AX_PMs,)}()
 end
 function get_int_PMst_site(ints::HPInts{AXP,AXM, NS, NB}) where {AXP,AXM,NS,NB}
     AX_MS = CA.getaxes(get_int_Mst_site(ints)) # note the t after Ms
-    AX_PMs = combine_axes((;P=AXP, Ms=AX_MS))
+    AX_PMs = compose_axes((;P=AXP, Ms=AX_MS))
     StaticComponentArrayInterpreter{(AX_PMs,)}()
 end
 

--- a/src/hybridprobleminterpreters.jl
+++ b/src/hybridprobleminterpreters.jl
@@ -1,0 +1,63 @@
+abstract type AbstractHybridProblemInterpreters end
+
+struct HybridProblemInterpreters{AXP, AXM, NS, NB} <: AbstractHybridProblemInterpreters 
+end;
+
+const HPInts = HybridProblemInterpreters
+
+# function get_hybridproblem_statics(prob::AbstractHybridProblem, scenario)
+#     θP, θM = get_hybridproblem_par_templates(prob; scenario)
+#     NS, NB = get_hybridproblem_n_site_and_batch(prob; scenario)
+#     (CA.getaxes(θP), CA.getaxes(θM), NS, NB)
+# end
+
+function HybridProblemInterpreters(prob::AbstractHybridProblem; scenario::Val)
+    # make sure interred get_hybridproblem_par_templates and n_site_and_n_batch
+    # error("'HybridProblemInterpreters(prob::AbstractHybridProblem; scenario)'",
+    # "is not inferred at caller level. Replace by ",
+    # "'HybridProblemInterpreters{get_hybridproblem_statics(prob; scenario)...}()'")
+    θP, θM = get_hybridproblem_par_templates(prob; scenario)
+    NS, NB = get_hybridproblem_n_site_and_batch(prob; scenario)
+    HybridProblemInterpreters{CA.getaxes(θP), CA.getaxes(θM), NS, NB}()
+end
+
+function get_int_P(::HPInts{AXP}) where AXP 
+    StaticComponentArrayInterpreter{AXP}()
+end
+function get_int_M(::HPInts{AXP,AXM}) where {AXP,AXM} 
+    StaticComponentArrayInterpreter{AXM}()
+end
+function get_int_Ms_batch(ints::HPInts{AXP,AXM, NS, NB}) where {AXP,AXM,NS,NB}
+    StaticComponentArrayInterpreter(AXM, (NB,))
+end
+function get_int_Mst_batch(ints::HPInts{AXP,AXM, NS, NB}) where {AXP,AXM,NS,NB}
+    StaticComponentArrayInterpreter((NB,), AXM)
+end
+function get_int_Ms_site(ints::HPInts{AXP,AXM, NS, NB}) where {AXP,AXM,NS,NB}
+    StaticComponentArrayInterpreter(AXM, (NS,))
+end
+function get_int_Mst_site(ints::HPInts{AXP,AXM, NS, NB}) where {AXP,AXM,NS,NB}
+    StaticComponentArrayInterpreter((NS,), AXM)
+end
+
+function get_int_PMs_batch(ints::HPInts{AXP,AXM, NS, NB}) where {AXP,AXM,NS,NB}
+    AX_MS = CA.getaxes(get_int_Ms_batch(ints))
+    AX_PMs = combine_axes((;P=AXP, Ms=AX_MS))
+    StaticComponentArrayInterpreter{(AX_PMs,)}()
+end
+function get_int_PMst_batch(ints::HPInts{AXP,AXM, NS, NB}) where {AXP,AXM,NS,NB}
+    AX_MS = CA.getaxes(get_int_Mst_batch(ints)) # note the t after Ms
+    AX_PMs = combine_axes((;P=AXP, Ms=AX_MS))
+    StaticComponentArrayInterpreter{(AX_PMs,)}()
+end
+function get_int_PMs_site(ints::HPInts{AXP,AXM, NS, NB}) where {AXP,AXM,NS,NB}
+    AX_MS = CA.getaxes(get_int_Ms_site(ints))
+    AX_PMs = combine_axes((;P=AXP, Ms=AX_MS))
+    StaticComponentArrayInterpreter{(AX_PMs,)}()
+end
+function get_int_PMst_site(ints::HPInts{AXP,AXM, NS, NB}) where {AXP,AXM,NS,NB}
+    AX_MS = CA.getaxes(get_int_Mst_site(ints)) # note the t after Ms
+    AX_PMs = combine_axes((;P=AXP, Ms=AX_MS))
+    StaticComponentArrayInterpreter{(AX_PMs,)}()
+end
+

--- a/src/init_hybrid_params.jl
+++ b/src/init_hybrid_params.jl
@@ -70,7 +70,7 @@ function init_hybrid_params(θP::AbstractVector{FT}, θM::AbstractVector{FT},
 end
 
 """
-    init_hybrid_ϕunc(cor_ends, ρ0=0f0; logσ2_logP, coef_logσ2_logMs, ρsP, ρsM)
+    init_hybrid_ϕunc(cor_ends, ρ0=0f0; logσ2_logP, coef_logσ2_ζMs, ρsP, ρsM)
 
 Initialize vector of additional parameter of the approximate posterior.
 
@@ -78,12 +78,12 @@ Arguments:
 - `cor_ends`: NamedTuple with entries, `P`, and `M`, respectively with 
    integer vectors of ending columns of parameters blocks
 - `ρ0`: default entry for ρsP and ρsM, defaults = 0f0.
-- `coef_logσ2_logM`: default column for `coef_logσ2_logMs`, defaults to `[-10.0, 0.0]`
+- `coef_logσ2_logM`: default column for `coef_logσ2_ζMs`, defaults to `[-10.0, 0.0]`
 
 Returns a `ComponentVector` of 
 - `logσ2_logP`: vector of log-variances of ζP (on log scale).
   defaults to -10
-- `coef_logσ2_logMs`: offset and slope for the log-variances of ζM scaling with 
+- `coef_logσ2_ζMs`: offset and slope for the log-variances of ζM scaling with 
    its value given by columns for each parameter in ζM, defaults to `[-10, 0]`
 - `ρsP` and `ρsM`: parameterization of the upper triangular cholesky factor 
   of the correlation matrices of ζP and ζM, default to all entries `ρ0`, which defaults to zero.
@@ -93,14 +93,14 @@ function init_hybrid_ϕunc(
         ρ0::FT = 0.0f0,
         coef_logσ2_logM::AbstractVector{FT} = FT[-10.0, 0.0];
         logσ2_logP::AbstractVector{FT} = fill(FT(-10.0), cor_ends.P[end]),
-        coef_logσ2_logMs::AbstractMatrix{FT} = reduce(
+        coef_logσ2_ζMs::AbstractMatrix{FT} = reduce(
             hcat, (coef_logσ2_logM for _ in 1:cor_ends.M[end])),
         ρsP = fill(ρ0, get_cor_count(cor_ends.P)),
         ρsM = fill(ρ0, get_cor_count(cor_ends.M)),
 ) where {FT}
     CA.ComponentVector(;
         logσ2_logP,
-        coef_logσ2_logMs,
+        coef_logσ2_ζMs,
         ρsP,
         ρsM)
 end

--- a/src/init_hybrid_params.jl
+++ b/src/init_hybrid_params.jl
@@ -72,7 +72,7 @@ function init_hybrid_params(θP::AbstractVector{FT}, θM::AbstractVector{FT},
 end
 
 """
-    init_hybrid_ϕunc(cor_ends, ρ0=0f0; logσ2_logP, coef_logσ2_ζMs, ρsP, ρsM)
+    init_hybrid_ϕunc(cor_ends, ρ0=0f0; logσ2_ζP, coef_logσ2_ζMs, ρsP, ρsM)
 
 Initialize vector of additional parameter of the approximate posterior.
 
@@ -83,7 +83,7 @@ Arguments:
 - `coef_logσ2_logM`: default column for `coef_logσ2_ζMs`, defaults to `[-10.0, 0.0]`
 
 Returns a `ComponentVector` of 
-- `logσ2_logP`: vector of log-variances of ζP (on log scale).
+- `logσ2_ζP`: vector of log-variances of ζP (on log scale).
   defaults to -10
 - `coef_logσ2_ζMs`: offset and slope for the log-variances of ζM scaling with 
    its value given by columns for each parameter in ζM, defaults to `[-10, 0]`
@@ -94,14 +94,14 @@ function init_hybrid_ϕunc(
         cor_ends::NamedTuple,
         ρ0::FT = 0.0f0,
         coef_logσ2_logM::AbstractVector{FT} = FT[-10.0, 0.0];
-        logσ2_logP::AbstractVector{FT} = fill(FT(-10.0), cor_ends.P[end]),
+        logσ2_ζP::AbstractVector{FT} = fill(FT(-10.0), cor_ends.P[end]),
         coef_logσ2_ζMs::AbstractMatrix{FT} = reduce(
             hcat, (coef_logσ2_logM for _ in 1:cor_ends.M[end])),
         ρsP = fill(ρ0, get_cor_count(cor_ends.P)),
         ρsM = fill(ρ0, get_cor_count(cor_ends.M)),
 ) where {FT}
     nt = (;
-        logσ2_logP,
+        logσ2_ζP,
         coef_logσ2_ζMs,
         ρsP,
         ρsM)

--- a/src/util_ca.jl
+++ b/src/util_ca.jl
@@ -10,4 +10,7 @@ function apply_preserve_axes(f, ca::CA.ComponentArray)
     CA.ComponentArray(f(CA.getdata(ca)), CA.getaxes(ca))
 end
 
+axis_length(ax::CA.AbstractAxis) = CA.lastindex(ax) - CA.firstindex(ax) + 1
+axis_length(::CA.FlatAxis) = 0
+axis_length(::CA.UnitRange) = 0
 

--- a/src/util_ca.jl
+++ b/src/util_ca.jl
@@ -11,7 +11,7 @@ function apply_preserve_axes(f, ca::CA.ComponentArray)
 end
 
 """
-    combine_axes(axtuples::NamedTuple)
+    compose_axes(axtuples::NamedTuple)
 
 Create a new 1d-axis that combines several other named axes-tuples
 such as of `key = getaxes(::AbstractComponentArray)`.
@@ -20,7 +20,7 @@ The new axis consists of several ViewAxes. If an axis-tuple consists only of one
 Otherwise a ShapedAxis is created wiht the axes-length of the others, essentially dropping
 component information that might be present in the dimensions.
 """
-function combine_axes(axtuples::NamedTuple)
+function compose_axes(axtuples::NamedTuple)
     ls = map(axtuple -> Val(prod(axis_length.(axtuple))), axtuples)
     # to work on types, need to construct value types of intervals
     intervals = _construct_invervals(;lengths=ls)

--- a/src/util_ca.jl
+++ b/src/util_ca.jl
@@ -17,7 +17,7 @@ Create a new 1d-axis that combines several other named axes-tuples
 such as of `key = getaxes(::AbstractComponentArray)`.
 
 The new axis consists of several ViewAxes. If an axis-tuple consists only of one axis, it is used for the view.
-Otherwise a ShapedAxis is created wiht the axes-length of the others, essentially dropping
+Otherwise a ShapedAxis is created with the axes-length of the others, essentially dropping
 component information that might be present in the dimensions.
 """
 function compose_axes(axtuples::NamedTuple)

--- a/src/util_ca.jl
+++ b/src/util_ca.jl
@@ -45,6 +45,8 @@ _val_value(::Val{x}) where x = x
 
 axis_length(ax::CA.AbstractAxis) = CA.lastindex(ax) - CA.firstindex(ax) + 1
 axis_length(::CA.FlatAxis) = 0
-axis_length(::CA.UnitRange) = 0
+axis_length(ax::CA.UnitRange) = length(ax)
+axis_length(ax::CA.ShapedAxis) = length(ax)
+axis_length(ax::CA.Shaped1DAxis) = length(ax)
 
 

--- a/src/util_ca.jl
+++ b/src/util_ca.jl
@@ -10,7 +10,30 @@ function apply_preserve_axes(f, ca::CA.ComponentArray)
     CA.ComponentArray(f(CA.getdata(ca)), CA.getaxes(ca))
 end
 
+"""
+    combine_axes(axtuples::NamedTuple)
+
+Create a new 1d-axis that combines several other named axes-tuples
+such as of `key = getaxes(::AbstractComponentArray)`.
+
+The new axis consists of several ViewAxes. If an axis-tuple consists only of one axis, it is used for the view.
+Otherwise a ShapedAxis is created wiht the axes-length of the others, essentially dropping
+component information that might be present in the dimensions.
+"""
+function combine_axes(axtuples::NamedTuple)
+    ls = map(axtuple -> Val(prod(axis_length.(axtuple))), axtuples)
+    # to work on types, need to construct value types of intervals
+    intervals = _construct_invervals(;lengths=ls)
+    named_intervals = (;zip(keys(axtuples),_val_value(intervals))...)
+    axc = map(named_intervals, axtuples) do interval, axtuple
+        ax = length(axtuple) == 1 ? axtuple[1] : CA.ShapedAxis(axis_length.(axtuple))
+        CA.ViewAxis(interval, ax)
+    end
+    CA.Axis(; axc...)
+end
+
 axis_length(ax::CA.AbstractAxis) = CA.lastindex(ax) - CA.firstindex(ax) + 1
 axis_length(::CA.FlatAxis) = 0
 axis_length(::CA.UnitRange) = 0
+
 

--- a/src/util_opt.jl
+++ b/src/util_opt.jl
@@ -21,3 +21,7 @@ callback_loss_fstate = (moditer, fstate) -> let iter = 1, moditer = moditer, fst
         return false
     end
 end
+
+
+
+

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Bijectors = "76274a88-744f-5084-9051-94815aaf08c4"
+BlockDiagonals = "0a1fb500-61f7-11e9-3c65-f5ef3456f9f0"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 DistributionFits = "45214091-1ed4-4409-9bcf-fdb48a05e921"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,8 @@ const GROUP = get(ENV, "GROUP", "All") # defined in in CI.yml
     if GROUP == "All" || GROUP == "Basic"
         #@safetestset "test" include("test/test_bijectors_utils.jl")
         @time @safetestset "test_bijectors_utils" include("test_bijectors_utils.jl")
+        #@safetestset "test" include("test/test_util_ca.jl")
+        @time @safetestset "test_util_ca" include("test_util_ca.jl")
         #@safetestset "test" include("test/test_ComponentArrayInterpreter.jl")
         @time @safetestset "test_ComponentArrayInterpreter" include("test_ComponentArrayInterpreter.jl")
         #@safetestset "test" include("test/test_hybridprobleminterpreters.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,8 @@ const GROUP = get(ENV, "GROUP", "All") # defined in in CI.yml
         @time @safetestset "test_bijectors_utils" include("test_bijectors_utils.jl")
         #@safetestset "test" include("test/test_ComponentArrayInterpreter.jl")
         @time @safetestset "test_ComponentArrayInterpreter" include("test_ComponentArrayInterpreter.jl")
+        #@safetestset "test" include("test/test_hybridprobleminterpreters.jl")
+        @time @safetestset "test_hybridprobleminterpreters" include("test_hybridprobleminterpreters.jl")
         #@safetestset "test" include("test/test_ModelApplicator.jl")
         @time @safetestset "test_ModelApplicator" include("test_ModelApplicator.jl")
         #@safetestset "test" include("test/test_gencovar.jl")

--- a/test/test_ComponentArrayInterpreter.jl
+++ b/test/test_ComponentArrayInterpreter.jl
@@ -169,7 +169,7 @@ end;
         end
         # @inferred f_n_within_cols(3) # inferred is only Any
         res = f_n_within_cols(3) # inferred is only 
-        pos = @inferred get_positions(res) # but wihtin this context size is known
+        pos = @inferred get_positions(res) # but within this context size is known
         @inferred res(pos)
     end
     #pos_outer = @inferred f_outer() # but inferred return type is Any

--- a/test/test_ComponentArrayInterpreter.jl
+++ b/test/test_ComponentArrayInterpreter.jl
@@ -100,6 +100,20 @@ end;
     testm(mmi)
 end;
 
+@testset "combine_axes" begin
+    @test (@inferred CP._add_interval(;agg=Val((1:3,)), length = Val(2))) == Val((1:3, 4:5))
+    ls = Val.((3,1,2))
+    @test (@inferred CP._construct_invervals(;lengths=ls)) == Val((1:3, 4:4, 5:6))
+    v1 = CA.ComponentVector(A=1:3)
+    v2 = CA.ComponentVector(B=1:2)
+    v3 = CA.ComponentVector(P=(x=1, y=2), Ms=zeros(3,2))
+    nt = (;C1=v1, C2=v2, C3=v3)
+    vt = CA.ComponentVector(; nt...)
+    axs = map(CA.getaxes, nt)
+    axc = @inferred CP.combine_axes(axs)
+    @test axc == CA.getaxes(vt)[1] 
+end
+
 @testset "stack_ca_int" begin
     mv = get_concrete(ComponentArrayInterpreter(CA.ComponentVector(c1=1:2, c2=1:3)))
     #mv = ComponentArrayInterpreter(CA.ComponentVector(c1=1:2, c2=1:3))

--- a/test/test_ComponentArrayInterpreter.jl
+++ b/test/test_ComponentArrayInterpreter.jl
@@ -1,14 +1,27 @@
 using Test
 using HybridVariationalInference
-using HybridVariationalInference: HybridVariationalInference as CM
+using HybridVariationalInference: HybridVariationalInference as CP
 using ComponentArrays: ComponentArrays as CA
 
-@testset "ComponentArrayInterpreter vector" begin
-    component_counts = comp_cnts = (; P=2, M=3, Unc=5)
-    m = ComponentArrayInterpreter(; comp_cnts...)
+using MLDataDevices, GPUArraysCore
+import Zygote
+
+# import CUDA, cuDNN
+using Suppressor
+
+gdev = Suppressor.@suppress gpu_device() # not loaded CUDA
+cdev = cpu_device()
+
+
+
+@testset "ComponentArrayInterpreter cv-vector" begin
+    #component_counts = comp_cnts = (; P=2, M=3, Unc=5)
+    component_counts = comp_cnts = CA.ComponentVector(P=1:2, M=1:3, Unc=1:5)
+    
+    m = ComponentArrayInterpreter(comp_cnts)
     testm = (m) -> begin
         #type of axes may differ
-        #@test CM._get_ComponentArrayInterpreter_axes(m) == (CA.Axis(P=1:2, M=3:5, Unc=6:10),)
+        #@test CP._get_ComponentArrayInterpreter_axes(m) == (CA.Axis(P=1:2, M=3:5, Unc=6:10),)
         @test length(m) == 10
         v = 1:length(m)
         cv = m(v)
@@ -31,8 +44,9 @@ end;
 # end
 
 @testset "ComponentArrayInterpreter matrix in vector" begin
-    component_shapes = (; P=2, M=(2, 3), Unc=5)
-    m = ComponentArrayInterpreter(; component_shapes...)
+    #component_shapes = (; P=2, M=(2, 3), Unc=5)
+    component_shapes = CA.ComponentVector(P=1:2, M=reshape(1:6,2, 3), Unc=1:5)
+    m = ComponentArrayInterpreter(component_shapes)
     testm = (m) -> begin
         @test length(m) == 13
         a = 1:length(m)
@@ -44,7 +58,8 @@ end;
 end;
 
 @testset "ComponentArrayInterpreter matrix and array" begin
-    mv = ComponentArrayInterpreter(; c1=2, c2=3)
+    #mv = ComponentArrayInterpreter(; c1=2, c2=3)
+    mv = ComponentArrayInterpreter(CA.ComponentVector(c1=1:2, c2=1:3))
     cv = mv(1:length(mv))
     n_col = 4
     mm = ComponentArrayInterpreter(cv, (n_col,)) # 1-tuple
@@ -85,6 +100,61 @@ end;
     testm(mmi)
 end;
 
+@testset "stack_ca_int" begin
+    mv = get_concrete(ComponentArrayInterpreter(CA.ComponentVector(c1=1:2, c2=1:3)))
+    #mv = ComponentArrayInterpreter(CA.ComponentVector(c1=1:2, c2=1:3))
+    cv = mv(1:length(mv))
+    n_col = 4
+    n_dims = (n_col,)
+    mm = @inferred CP.stack_ca_int(mv, Val((n_col,))) # 1-tuple
+    @inferred get_positions(mm) # sizes are inferred here
+    testm = (m) -> begin
+        @test length(mm) == length(cv) * n_col
+        cm = mm(1:length(mm))
+        #cm[:c1,:]
+        @test cm[:c1, 2] == 6:7
+    end
+    testm(mm)
+    #
+    n_z = 3
+    mm = @inferred stack_ca_int(mv, Val((n_col, n_z)))
+    testm = (m) -> begin
+        @test mm isa AbstractComponentArrayInterpreter
+        @test length(mm) == length(cv) * n_col * n_z
+        cm = mm(1:length(mm))
+        @test cm[:c1, 2, 2] == 26:27
+    end
+    testm(mm)
+    #
+    n_row = 3
+    mm = @inferred stack_ca_int(Val((n_row,)), mv)
+    testm = (m) -> begin
+        @test mm isa AbstractComponentArrayInterpreter
+        @test length(mm) == n_row * length(mv)
+        cm = mm(1:length(mm))
+        @test cm[2, :c1] == [2, 5]
+    end
+    testm(mm)
+    #
+    f_n_within = (n) -> begin
+        mm = @inferred stack_ca_int(Val((n,)), mv)
+    end
+    @test_broken @inferred f_n_within(3) # inferred is only 
+    f_outer = () -> begin
+        f_n_within_cols = (n) -> begin
+            mm = @inferred stack_ca_int(mv, Val((n,)))
+            mm = get_concrete(ComponentArrayInterpreter(mv, (3,))) # same effects
+        end
+        # @inferred f_n_within_cols(3) # inferred is only Any
+        res = f_n_within_cols(3) # inferred is only 
+        pos = @inferred get_positions(res) # but wihtin this context size is known
+        @inferred res(pos)
+    end
+    #pos_outer = @inferred f_outer() # but inferred return type is Any
+    pos_outer = f_outer()
+end;
+
+
 @testset "empty ComponentVector" begin
     x = CA.ComponentVector{Float32}()
     int1 = ComponentArrayInterpreter(x) 
@@ -95,5 +165,85 @@ end;
     @test int3 == int1
 end;
 
+@testset "combine ComponentArrayInterpreters" begin
+    int1 = get_concrete(ComponentArrayInterpreter(CA.ComponentVector(x1=1:3, x2=4:5)))
+    int2 = get_concrete(ComponentArrayInterpreter(CA.ComponentVector(y1=1:2, y2=3:5)))
+    intm2 = get_concrete(ComponentArrayInterpreter(int2, (3,)))
+    #intc = ComponentArrayInterpreter((a=int1, b=int2))
+    ints = (a=int1, b=intm2)
+    intc = @inferred ComponentArrayInterpreter(;ints...)
+    # @usingany Cthulhu
+    # @descend_code_warntype CP.StaticComponentArrayInterpreter(a=int1, b=int2)
+    # @descend_code_warntype CP.combine_axes(map(x -> CA.getaxes(x), ints))
+    () -> begin
+        nt = (a=int1, b=int2)
+        nt isa NamedTuple{keys, <:NTuple{N, <:AbstractComponentArrayInterpreter}} where {keys, N}
+        nt isa NamedTuple{keys, <:NTuple{N}} where {keys, N}
+        nt isa NamedTuple{keys} where {keys}
+    end
+    #
+    v3 = CA.ComponentVector(a = get_positions(int1), b = get_positions(intm2))
+    intc2 = ComponentArrayInterpreter(v3)
+    @test intc == intc2
+    v3r = @inferred get_concrete(intc)(CA.getdata(v3))
+    @test v3r == v3
+    #@usingany BenchmarkTools
+    #@benchmark ComponentArrayInterpreter(a=int1, b=int2) # 6 allocations?
+    #@benchmark CP.StaticComponentArrayInterpreter(a=int1, b=int2) # still 5 allocations?
+    #@benchmark CP.combine_axes((a=int1, b=int2)) # still 5 allocations?
+    #@usingany Cthulhu
+    # Cthulhu.@descend_code_typed ComponentArrayInterpreter(a=int1, b=int2)
+    # @code_typed get_concrete(ComponentArrayInterpreter(a=int1, b=int2))
+    if gdev isa MLDataDevices.AbstractGPUDevice 
+        vd = gdev(CA.getdata(v3))
+        f1 = (v) -> begin
+            intc = get_concrete(ComponentArrayInterpreter(a=int1, b=intm2))
+            vc = intc(v)
+            sum(vc.a.x1)::eltype(vc) # eltype necessary
+            #sum(vc.a.x1)
+        end
+        @test @inferred f1(vd) == sum(v3.a.x1)
+        df1 = Zygote.gradient(v -> f1(v), vd)[1];
+        @test df1 isa AbstractGPUArray
+    end
+
+end;
+
+@testset "type inference concrete Array interpreter" begin
+    cai0 = ComponentArrayInterpreter(CA.ComponentVector(x = 1:3))
+    cai = get_concrete(cai0)
+    v = collect(1:length(cai))
+    cv = cai(v)
+
+    cv2 = @inferred CP.tmpf(v; cv) # cai by keyword argument
+    #cv2 = @inferred CP.tmpf(v; cv=nothing, cai = cai0) # not inferred
+    cv2 = CP.tmpf(v; cv=nothing, cai = cai0) # not inferred
+    cv2 = @inferred CP.tmpf1(v; cai = get_concrete(cai0)) # cai by keyword argument
+    #cv2 = @inferred CP.tmpf1(v; cai = cai0) # inside function does not infer
+    cv2 = CP.tmpf1(v; cai = cai0) # get_concrete inside function does not infer outside
+    cv2 = @inferred CP.tmpf2(v; cai=cai0) # only when specifying return type
+    # () -> begin
+    #     #cv2 = @code_warntype CP.tmpf(cai0) # Any
+    #     #cv2 = @code_warntype CP.tmpf(cai)  # ok
+    #     cv2 = @code_warntype CP.tmpf(v;cv, cai) # ok, keywords work
+    #     cv2 = @code_warntype CP.tmpf(v;cv, cai=cai0) # Any
+    #     cv2 = @code_warntype CP.tmpf(v; cv) # ok !!
+    #     cv2 = CP.tmpf(v; cv)
+    #     typeof(cv2)
+
+    #     cv2 = CP.tmpf2(v; cai=cai)
+    #     cv2 = @code_warntype CP.tmpf2(v; cai=cai) #ok
+    #     cv2 = @code_warntype CP.tmpf2(v; cai=cai0) #
+    #     cv2 = @code_warntype sum(CP.tmpf2(v; cai=cai0)) #
+    #     cv2 = @code_warntype sum(CP.tmpf2(v; cai=cai0).x) #
+    #     # @usingany Cthulhu
+    #     # @descend_code_warntype CP.tmpf2(v; cai=cai0) 
+    #     # @code_warntype CP.tmpf2(v; cai=cai0) 
+    #     cv2 = CP.tmpf2(v; cai=cai0) #
+    # end
+end
+
+tmpf = () -> 4::Integer
+tmp = @inferred tmpf()
 
 

--- a/test/test_ComponentArrayInterpreter.jl
+++ b/test/test_ComponentArrayInterpreter.jl
@@ -101,9 +101,9 @@ end;
 end;
 
 @testset "combine_axes" begin
-    @test (@inferred CP._add_interval(;agg=Val((1:3,)), length = Val(2))) == Val((1:3, 4:5))
+    @test (@inferred CP._add_interval(;ranges=(Val(1:3),), length = Val(2))) == (Val(1:3), Val(4:5))
     ls = Val.((3,1,2))
-    @test (@inferred CP._construct_invervals(;lengths=ls)) == Val((1:3, 4:4, 5:6))
+    @test (@inferred CP._construct_invervals(;lengths=ls)) == Val.((1:3, 4:4, 5:6))
     v1 = CA.ComponentVector(A=1:3)
     v2 = CA.ComponentVector(B=1:2)
     v3 = CA.ComponentVector(P=(x=1, y=2), Ms=zeros(3,2))

--- a/test/test_ComponentArrayInterpreter.jl
+++ b/test/test_ComponentArrayInterpreter.jl
@@ -12,13 +12,20 @@ using Suppressor
 gdev = Suppressor.@suppress gpu_device() # not loaded CUDA
 cdev = cpu_device()
 
-
+@testset "construct StaticComponentArrayInterepreter" begin
+    intv = @inferred CP.StaticComponentArrayInterpreter(CA.ComponentVector(a=1:3, b=reshape(4:9,3,2)))
+    ints = @inferred CP.StaticComponentArrayInterpreter((;a=Val(3), b = Val((3,2))))
+    # @descend_code_warntype CP.StaticComponentArrayInterpreter((;a=Val(3), b = Val((3,2))))
+    @test ints == intv
+end
 
 @testset "ComponentArrayInterpreter cv-vector" begin
-    component_counts = comp_cnts = (; P=2, M=3, Unc=5)
+    component_counts = comp_cnts = (; P=2, M=3, Unc=5)  
+    comp_cnts_val = (; P=Val(2), M=Val(3), Unc=Val(5))
     #component_counts = comp_cnts = CA.ComponentVector(P=1:2, M=1:3, Unc=1:5)
     
-    m = ComponentArrayInterpreter(comp_cnts)
+    m = @inferred ComponentArrayInterpreter(comp_cnts)
+    m2 = @inferred CP.StaticComponentArrayInterpreter(comp_cnts_val)
     get_positions(m)
     testm = (m) -> begin
         #type of axes may differ
@@ -29,6 +36,7 @@ cdev = cpu_device()
         @test cv.Unc == 6:10
     end
     testm(m)
+    #m = @inferred get_concrete(m)
     m = get_concrete(m)
     testm(get_concrete(m))
     Base.isconcretetype(typeof(m))

--- a/test/test_HybridProblem.jl
+++ b/test/test_HybridProblem.jl
@@ -106,7 +106,7 @@ test_without_flux = (scenario) -> begin
         end
     end
 
-    @testset "loss_gf  $(last(scenario))" begin
+    @testset "loss_gf $(last(scenario))" begin
         #----------- fit g and θP to y_o
         rng = StableRNG(111)
         g, ϕg0 = get_hybridproblem_MLapplicator(prob; scenario)

--- a/test/test_HybridProblem.jl
+++ b/test/test_HybridProblem.jl
@@ -263,7 +263,7 @@ test_with_flux = (scenario) -> begin
             @test cdev(ϕ.unc.ρsM)[1] > 0 
             @test probo.ϕunc == cdev(ϕ.unc)
             n_sample_pred = 22
-            (; y, θsP, θsMs) = predict_gf(
+            (; y, θsP, θsMs) = predict_hvi(
                 rng, probo; scenario = scenf, n_sample_pred, is_inferred=Val(true));            
             (_xM, _xP, _y_o, _y_unc, _i_sites) = get_hybridproblem_train_dataloader(prob; scenario).data
             @test size(y) == (size(_y_o)..., n_sample_pred)
@@ -279,7 +279,7 @@ test_with_flux = (scenario) -> begin
                 @test probo.ϕunc == cdev(ϕ.unc)
                 # predict using problem and its associated dataloader
                 n_sample_pred = 201
-                (; y, θsP, θsMs) = predict_gf(rng, probo; scenario = scenf, n_sample_pred);            
+                (; y, θsP, θsMs) = predict_hvi(rng, probo; scenario = scenf, n_sample_pred);            
                 # to inspect correlations among θP and θMs construct ComponentVector
                 hpints = HybridProblemInterpreters(prob; scenario)
                 int_mPMs = stack_ca_int(Val((n_sample_pred,)), get_int_PMst_site(hpints))
@@ -317,7 +317,7 @@ test_with_flux = (scenario) -> begin
             );
             @test CA.getdata(ϕ) isa GPUArraysCore.AbstractGPUVector
             n_sample_pred = 11
-            (; y, θsP, θsMs) = predict_gf(
+            (; y, θsP, θsMs) = predict_hvi(
                 rng, probo; scenario = scenf, n_sample_pred,is_inferred = Val(true));
             # @test cdev(ϕ.unc.ρsM)[1] > 0 # too few iterations
         end;    

--- a/test/test_HybridProblem.jl
+++ b/test/test_HybridProblem.jl
@@ -19,32 +19,39 @@ using Suppressor
 
 cdev = cpu_device()
 
-#scenario = (:default,)
-#scenario = (:covarK2,)
+#scenario = Val((:default,))
+#scenario = Val((:covarK2,))
+#scen = CP._val_value(scenario)
 
-
-construct_problem = (;scenario=(:default,)) -> begin
+function construct_problem(; scenario::Val{scen}) where scen
     FT = Float32
     θP = CA.ComponentVector{FT}(r0=0.3, K2=2.0)
     θM = CA.ComponentVector{FT}(r1=0.5, K1=0.2)
-    transP = elementwise(exp)
-    transM = Stacked(elementwise(identity), elementwise(exp))
+    transP = Stacked((CP.Exp(),),(1:2,))  # elementwise(exp)
+    transM = Stacked(identity, CP.Exp()) # test different par transforms
     cor_ends = (P=1:length(θP), M=[length(θM)]) # assume r0 independent of K2
     int_θdoubleMM = get_concrete(ComponentArrayInterpreter(
         flatten1(CA.ComponentVector(; θP, θM))))
-    function f_doubleMM(θ::AbstractVector, x)
+    function f_doubleMM(θ::AbstractVector{ET}, x; intθ1) where ET
         # extract parameters not depending on order, i.e whether they are in θP or θM
-        θc = int_θdoubleMM(θ)
-        r0, r1, K1, K2 = θc[(:r0, :r1, :K1, :K2)]
-        y = r0 .+ r1 .* x.S1 ./ (K1 .+ x.S1) .* x.S2 ./ (K2 .+ x.S2)
+        local θc = intθ1(θ)
+        (r0, r1, K1, K2) = map((:r0, :r1, :K1, :K2)) do par
+            CA.getdata(θc[par])::ET
+        end
+        local y = r0 .+ r1 .* x.S1 ./ (K1 .+ x.S1) .* x.S2 ./ (K2 .+ x.S2)
         return (y)
-    end
-    function f_doubleMM_with_global(θP::AbstractVector, θMs::AbstractMatrix, xP)
-        #Main.@infiltrate_main
-        #first(eachcol(xP))
-        pred_sites = applyf(f_doubleMM, θMs, θP, CA.ComponentVector{FT}(), eachcol(xP))
-        pred_global = eltype(pred_sites)[]
-        return pred_global, pred_sites
+    end    
+    f_doubleMM_sites = let intθ1 = int_θdoubleMM, f_doubleMM=f_doubleMM,
+        θFix = CA.ComponentVector{FT}()
+        function f_doubleMM_with_global_inner(
+            θP::AbstractVector{ET}, θMs::AbstractMatrix, xP
+        ) where ET
+            #first(eachcol(xP))
+            local θMst = θMs'  # map_f_each:site requires sites-last format
+            local pred_sites = map_f_each_site(f_doubleMM, θMst, θP, θFix, xP; intθ1)
+            local pred_global = eltype(pred_sites)[]
+            return pred_global, pred_sites
+        end
     end
     n_out = length(θM)
     rng = StableRNG(111)
@@ -52,9 +59,9 @@ construct_problem = (;scenario=(:default,)) -> begin
     n_site, n_batch = get_hybridproblem_n_site_and_batch(CP.DoubleMM.DoubleMMCase(); scenario)
     # dependency on DeoubleMMCase -> take care of changes in covariates
     (; xM, θP_true, θMs_true, xP, y_global_true, y_true, y_global_o, y_o, y_unc
-    ) = gen_hybridproblem_synthetic(rng, DoubleMM.DoubleMMCase())
+    ) = gen_hybridproblem_synthetic(rng, DoubleMM.DoubleMMCase(); scenario)
     n_covar = size(xM,1)
-    n_input = (:covarK2 ∈ scenario) ? n_covar +1 : n_covar
+    n_input = (:covarK2 ∈ scen) ? n_covar +1 : n_covar
     g_chain = SimpleChain(
         static(n_input), # input dimension (optional)
         # dense layer with bias that maps to 8 outputs and applies `tanh` activation
@@ -72,32 +79,57 @@ construct_problem = (;scenario=(:default,)) -> begin
     #         MLUtils.DataLoader((xM, xP, y_o, y_unc, i_sites), batchsize=n_batch, partial=false)
     #     end
     # end
-    train_dataloader = MLUtils.DataLoader((xM, xP, y_o, y_unc, i_sites), batchsize=n_batch, partial=false)
+    train_dataloader = MLUtils.DataLoader(
+        (xM, xP, y_o, y_unc, i_sites), batchsize=n_batch, partial=false)
     θall = vcat(θP, θM)
-    priors_dict = Dict{Symbol, Distribution}(keys(θall) .=> fit.(LogNormal, θall, QuantilePoint.(θall .* 3, 0.95)))
+    priors_dict = Dict{Symbol, Distribution}(
+        keys(θall) .=> fit.(LogNormal, θall, QuantilePoint.(θall .* 3, 0.95)))
     priors_dict[:r1] = fit(Normal, θall.r1, qp_uu(3 * θall.r1)) # not transformed to log-scale
     # scale (0,1) outputs MLmodel to normal distribution fitted to priors translated to ζ
     priorsM = [priors_dict[k] for k in keys(θM)]
+    lowers, uppers = get_quantile_transformed(priorsM, transM)
     app, ϕg0 = construct_ChainsApplicator(rng, g_chain)
-    g_chain_scaled = NormalScalingModelApplicator(app, priorsM, transM, FT)
+    g_chain_scaled = NormalScalingModelApplicator(app, lowers, uppers, FT)
     #g_chain_scaled = app
     ϕunc0 = init_hybrid_ϕunc(cor_ends, zero(FT)) 
-    pbm_covars = (:covarK2 ∈ scenario) ? (:K2,) : ()
+    pbm_covars = (:covarK2 ∈ scen) ? (:K2,) : ()
     HybridProblem(θP, θM, g_chain_scaled, ϕg0, ϕunc0, 
-        f_doubleMM_with_global, f_doubleMM_with_global, priors_dict, py,
+        f_doubleMM_sites, f_doubleMM_sites, priors_dict, py,
         transM, transP, train_dataloader, n_covar, n_site, n_batch, 
         cor_ends, pbm_covars)
+end 
+
+@testset "f_doubleMM from ProbSpec" begin
+    θ1 = CA.ComponentVector(r0=1.1, r1=2.1, K1=3.1, K2=4.1)
+    θ2 = reverse(θ1)
+    int_θdoubleMM = get_concrete(ComponentArrayInterpreter(θ2))
+    xP1 = CA.ComponentVector(S1=[1,1,0.3,0.1], S2=[0.1,0.3,1,1,])
+    n_site = 4
+    xPint = ComponentArrayInterpreter((n_site,), ComponentArrayInterpreter(xP1))
+    xP = xPint(repeat(xP1, outer=(1,4)))
+    function test_f_doubleMM(θ::AbstractVector{ET}, x; intθ1) where ET
+        # extract parameters not depending on order, i.e whether they are in θP or θM
+        θc = intθ1(θ)
+        (r0, r1, K1, K2) = map((:r0, :r1, :K1, :K2)) do par
+            CA.getdata(θc[par])::ET
+        end
+        r0 .+ r1 .* x.S1 ./ (K1 .+ x.S1) .* x.S2 ./ (K2 .+ x.S2)
+    end    
+    y = @inferred test_f_doubleMM(CA.getdata(θ2), xP1; intθ1 = int_θdoubleMM)
+    # using ShareAdd; @usingany Cthulhu
+    # @descend_code_warntype test_f_doubleMM(CA.getdata(θ2), xP1)
 end
 
 test_without_flux = (scenario) -> begin
+    #scen = CP._val_value(scenario)
     gdev = @suppress gpu_device()
 
     prob = probc = construct_problem(;scenario);
     #@descend construct_problem(;scenario)
 
-    @testset "n_input and pbm_covars  $(last(scenario))" begin
+    @testset "n_input and pbm_covars  $(last(CP._val_value(scenario)))" begin
         g, ϕ_g = get_hybridproblem_MLapplicator(prob; scenario);
-        if :covarK2 ∈ scenario
+        if :covarK2 ∈ CP._val_value(scenario)
             @test g.app.m.inputdim == (static(6),) # 5 + 1 (ncovar + n_pbm)
             @test get_hybridproblem_pbmpar_covars(prob; scenario) == (:K2,)
         else
@@ -106,7 +138,7 @@ test_without_flux = (scenario) -> begin
         end
     end
 
-    @testset "loss_gf $(last(scenario))" begin
+    @testset "loss_gf $(last(CP._val_value(scenario)))" begin
         #----------- fit g and θP to y_o
         rng = StableRNG(111)
         g, ϕg0 = get_hybridproblem_MLapplicator(prob; scenario)
@@ -125,8 +157,12 @@ test_without_flux = (scenario) -> begin
 
         # Pass the site-data for the batches as separate vectors wrapped in a tuple
         y_global_o = Float64[]
-        loss_gf = get_loss_gf(g, transM, transP, f, y_global_o, intϕ; pbm_covars)
-        l1 = loss_gf(p0, first(train_loader)...)
+        loss_gf = get_loss_gf(g, transM, transP, f, y_global_o, intϕ; 
+            pbm_covars, n_site_batch = n_batch)
+        (_xM, _xP, _y_o, _y_unc, _i_sites) = first(train_loader)
+        l1 = @inferred (
+            # @descend_code_warntype (
+            loss_gf(p0, _xM, _xP, _y_o, _y_unc, _i_sites))
         tld = first(train_loader)
         gr = Zygote.gradient(p -> loss_gf(p, tld...)[1], CA.getdata(p0))
         @test gr[1] isa Vector
@@ -146,8 +182,8 @@ test_without_flux = (scenario) -> begin
     end
 end
 
-test_without_flux((:default,))
-test_without_flux((:covarK2,))
+test_without_flux(Val((:default,)))
+test_without_flux(Val((:covarK2,)))
 
 import CUDA, cuDNN
 using GPUArraysCore
@@ -159,7 +195,7 @@ gdev = gpu_device()
 test_with_flux = (scenario) -> begin
     prob = probc = construct_problem(;scenario);
 
-    @testset "HybridPointSolver $(last(scenario))" begin
+    @testset "HybridPointSolver $(last(CP._val_value(scenario)))" begin
         rng = StableRNG(111)
         solver = HybridPointSolver(; alg=Adam(0.02))
         (; ϕ, resopt, probo) = solve(prob, solver; scenario, rng,
@@ -169,6 +205,7 @@ test_with_flux = (scenario) -> begin
             maxiters=200,
             gdev = identity,
             #gpu_handler = NullGPUDataHandler
+            is_inferred = Val(true),
         )
         (; θP) = get_hybridproblem_par_templates(prob; scenario)
         θPo = (() -> begin
@@ -179,7 +216,7 @@ test_with_flux = (scenario) -> begin
         @test ϕ.ϕP.K2 < 1.5 * log(θP.K2)
     end;
 
-    @testset "HybridPosteriorSolver  $(last(scenario))" begin
+    @testset "HybridPosteriorSolver  $(last(CP._val_value(scenario)))" begin
         rng = StableRNG(111)
         solver = HybridPosteriorSolver(; alg=Adam(0.02), n_MC=3)
         (; ϕ, θP, resopt) = solve(prob, solver; scenario, rng,
@@ -187,7 +224,8 @@ test_with_flux = (scenario) -> begin
             #maxiters = 20 # too small so that it yields error
             maxiters=37,
             θmean_quant = 0.01,   # test constraining mean to initial prediction     
-            gdev = identity
+            gdev = identity,
+            is_inferred = Val(true),
         )
         θPt = get_hybridproblem_par_templates(prob; scenario).θP
         @test θP.r0 < 1.5 * θPt.r0
@@ -196,9 +234,11 @@ test_with_flux = (scenario) -> begin
         prob.θP
     end;
 
+
+
     if gdev isa MLDataDevices.AbstractGPUDevice 
-        @testset "HybridPosteriorSolver gpu  $(last(scenario))" begin
-            scenf = (scenario..., :use_Flux, :use_gpu, :omit_r0)
+        @testset "HybridPosteriorSolver gpu  $(last(CP._val_value(scenario)))" begin
+            scenf = Val((CP._val_value(scenario)..., :use_Flux, :use_gpu, :omit_r0))
             rng = StableRNG(111)
             # here using DoubleMMCase() directly rather than construct_problem
             #(;transP, transM) = get_hybridproblem_transforms(DoubleMM.DoubleMMCase(); scenario = scenf)
@@ -210,6 +250,7 @@ test_with_flux = (scenario) -> begin
                 maxiters = 37, # smallest value by trial and error
                 #maxiters = 20 # too small so that it yields error
                 θmean_quant = 0.01,   # test constraining mean to initial prediction     
+                is_inferred = Val(true),
             );
             @test CA.getdata(ϕ) isa GPUArraysCore.AbstractGPUVector
             #@test cdev(ϕ.unc.ρsM)[1] > 0 # too few iterations in test -> may fail
@@ -217,9 +258,17 @@ test_with_flux = (scenario) -> begin
             solver = HybridPosteriorSolver(; alg=Adam(0.02), n_MC=3)
             (; ϕ, θP, resopt, probo) = solve(prob, solver; scenario = scenf,
                 maxiters = 37, 
+                is_inferred = Val(true),
             );
             @test cdev(ϕ.unc.ρsM)[1] > 0 
             @test probo.ϕunc == cdev(ϕ.unc)
+            n_sample_pred = 22
+            (; y, θsP, θsMs) = predict_gf(
+                rng, probo; scenario = scenf, n_sample_pred, is_inferred=Val(true));            
+            (_xM, _xP, _y_o, _y_unc, _i_sites) = get_hybridproblem_train_dataloader(prob; scenario).data
+            @test size(y) == (size(_y_o)..., n_sample_pred)
+            @test size(θsP) == (size(probo.θP,1), n_sample_pred)
+            
             test_correlation = () -> begin
                 n_epoch = 20 # requires 
                 (; ϕ, θP, resopt, probo) = solve(prob, solver; scenario = scenf,
@@ -229,20 +278,30 @@ test_with_flux = (scenario) -> begin
                 @test cdev(ϕ.unc.ρsM)[1] > 0 
                 @test probo.ϕunc == cdev(ϕ.unc)
                 # predict using problem and its associated dataloader
-                (; θ, y, entropy_ζ) = predict_gf(rng, probo; scenario = scenf, n_sample_pred = 200);            
-                mean_θ = CA.ComponentVector(mean(CA.getdata(θ); dims = 2)[:, 1], CA.getaxes(θ[:, 1])[1])
-                residθ = θ .- mean_θ
-                cr = cor(CA.getdata(residθ));
+                n_sample_pred = 201
+                (; y, θsP, θsMs) = predict_gf(rng, probo; scenario = scenf, n_sample_pred);            
+                # to inspect correlations among θP and θMs construct ComponentVector
+                hpints = HybridProblemInterpreters(prob; scenario)
+                int_mPMs = stack_ca_int(Val((n_sample_pred,)), get_int_PMst_site(hpints))
+                θs =  int_mPMs(CP.flatten_hybrid_pars(θsP, θsMs))
+                mean_θ = CA.ComponentVector(vec(mean(CA.getdata(θs), dims=1)), last(CA.getaxes(θs)))
+                mean_θ.Ms
+                sd_θ = CA.ComponentVector(vec(std(CA.getdata(θs), dims=1)), last(CA.getaxes(θs)))
+                sd_θ.Ms
+                pos = get_positions(ComponentArrayInterpreter(mean_θ))
+                residθs = θs .- mean_θ
+
+                cr = cor(CA.getdata(residθs'))
+                pos_P = get_positions(ComponentArrayInterpreter(θs[:P,1]))
                 i_sites = [1,2,3]
-                tmp = CA.ComponentArray(collect(axes(θ[:,1],1)), CA.getaxes(θ[:,1]));
                 #ax = map(x -> axes(x,1), get_hybridproblem_par_templates(probo; scenario = scenf))
-                is = vcat(tmp.P, vec(tmp.Ms[:,i_sites]))
+                is = vcat(pos.P, vec(pos.Ms[i_sites,:]))
                 cr[is,is]
             end
 
         end;
-        @testset "HybridPosteriorSolver also f on gpu  $(last(scenario))" begin
-            scenf = (scenario..., :use_Flux, :use_gpu, :omit_r0, :f_on_gpu)
+        @testset "HybridPosteriorSolver also f on gpu  $(last(CP._val_value(scenario)))" begin
+            scenf = Val((CP._val_value(scenario)..., :use_Flux, :use_gpu, :omit_r0, :f_on_gpu))
             rng = StableRNG(111)
             probg = HybridProblem(DoubleMM.DoubleMMCase(); scenario = scenf);
             #prob = CP.update(probg, transM = identity, transP = identity);
@@ -253,13 +312,17 @@ test_with_flux = (scenario) -> begin
                 maxiters = 37, # smallest value by trial and error
                 #maxiters = 20 # too small so that it yields error
                 #θmean_quant = 0.01,   # TODO make possible on gpu
-                cdev = identity # do not move ζ to cpu # TODO infer in solve from scenario
+                cdev = identity, # do not move ζ to cpu # TODO infer in solve from scenario
+                is_inferred = Val(true),
             );
             @test CA.getdata(ϕ) isa GPUArraysCore.AbstractGPUVector
+            n_sample_pred = 11
+            (; y, θsP, θsMs) = predict_gf(
+                rng, probo; scenario = scenf, n_sample_pred,is_inferred = Val(true));
             # @test cdev(ϕ.unc.ρsM)[1] > 0 # too few iterations
         end;    
     end # if gdev isa MLDataDevices.AbstractGPUDevice 
 end # test_with flux
 
-test_with_flux((:default,))
-test_with_flux((:covarK2,))
+test_with_flux(Val((:default,)))
+test_with_flux(Val((:covarK2,)))

--- a/test/test_doubleMM.jl
+++ b/test/test_doubleMM.jl
@@ -228,7 +228,7 @@ end
         #optprob, Adam(0.02), callback = callback_loss(100), maxiters = 5000);
         optprob, Adam(0.02), maxiters = 1000)
 
-    l1, y_pred_global, y_pred, θMs_pred, θP_pred = loss_gf2(res.u, train_loader.data...)
+    l1, y_pred, θMs_pred, θP_pred = loss_gf2(res.u, train_loader.data...)
     #l1, y_pred_global, y_pred, θMs_pred = loss_gf(p0, xM, xP, y_o, y_unc);
     θMs_pred = CA.ComponentArray(θMs_pred, CA.getaxes(θMs_true'))
     #TODO @test isapprox(par_templates.θP, intϕ(res.u).ϕP, rtol = 0.15)

--- a/test/test_doubleMM.jl
+++ b/test/test_doubleMM.jl
@@ -1,6 +1,6 @@
 using Test
 using HybridVariationalInference
-using HybridVariationalInference: HybridVariationalInference as HVI
+using HybridVariationalInference: HybridVariationalInference as CP
 using StableRNGs
 using Random
 using Statistics
@@ -22,9 +22,9 @@ gdev = gpu_device()
 cdev = cpu_device()
 
 prob = DoubleMM.DoubleMMCase()
-scenario = (:default,)
+scenario = Val((:default,))
 #using Flux
-#scenario = (:use_Flux,)
+#scenario = Val((:use_Flux,))
 
 par_templates = get_hybridproblem_par_templates(prob; scenario)
 
@@ -60,33 +60,38 @@ end
     is = repeat((1:length(θP_true))', n_site)
     θvec = CA.ComponentVector(P = θP_true, Ms = θMs_true)
     #xPM = map(xP1s -> repeat(xP1s', n_site), xP[1])
-    xPM = (S1 = CA.getdata(xP[:S1,:])', S2 = CA.getdata(xP[:S2,:])')
+    xPM = (S1 = CA.getdata(xP[:S1, :])', S2 = CA.getdata(xP[:S2, :])')
     #θ = hcat(θP_true[is], θMs_true')
     intθ1 = get_concrete(ComponentArrayInterpreter(vcat(θP_true, θMs_true[:, 1])))
     #θpos = get_positions(intθ1)
     intθ = get_concrete(ComponentArrayInterpreter((n_site,), intθ1))
-    fy = (θvec, xPM) -> begin
-        θ = hcat(CA.getdata(θvec.P[is]), CA.getdata(θvec.Ms'))
-        y = HVI.DoubleMM.f_doubleMM(θ, xPM, intθ)
-        #y = HVI.DoubleMM.f_doubleMM(θ, xPM, θpos)
+    # TODO replace is by ComponentArrayInterpreter
+    fy = let is = is, intθ = intθ
+        (θvec, xPM) -> begin
+            θ = hcat(CA.getdata(θvec.P[is]), CA.getdata(θvec.Ms'))
+            y = CP.DoubleMM.f_doubleMM(θ, xPM, intθ)
+            #y = @inferred CP.DoubleMM.f_doubleMM(θ, xPM, intθ)
+            # @descend_code_warntype CP.DoubleMM.f_doubleMM(θ, xPM, intθ)
+            #y = CP.DoubleMM.f_doubleMM(θ, xPM, θpos)
+        end
     end
-    y = fy(θvec, xPM)
-    y_exp = applyf(HVI.DoubleMM.f_doubleMM, θMs_true, θP_true,
+    y = @inferred fy(θvec, xPM)
+    y_exp = applyf(CP.DoubleMM.f_doubleMM, θMs_true, θP_true,
         Vector{eltype(θP_true)}(undef, 0), eachcol(xP), intθ1)
     @test y == y_exp'
     ygrad = Zygote.gradient(θv -> sum(fy(θv, xPM)), θvec)[1]
     if gdev isa MLDataDevices.AbstractGPUDevice
         # θg = gdev(θ)
         # xPMg = gdev(xPM)
-        # yg = HVI.DoubleMM.f_doubleMM(θg, xPMg, intθ);
-        θvecg = gdev(θvec); # errors without ";"
+        # yg = CP.DoubleMM.f_doubleMM(θg, xPMg, intθ);
+        θvecg = gdev(θvec) # errors without ";"
         xPMg = gdev(xPM)
-        yg = fy(θvecg, xPMg)
+        yg = @inferred fy(θvecg, xPMg)
         @test cdev(yg) == y_exp'
-        ygradg = Zygote.gradient(θv -> sum(fy(θv, xPMg)), θvecg)[1] 
+        ygradg = Zygote.gradient(θv -> sum(fy(θv, xPMg)), θvecg)[1]
         @test ygradg isa CA.ComponentArray
         @test CA.getdata(ygradg) isa GPUArraysCore.AbstractGPUArray
-        ygradgc = HVI.apply_preserve_axes(cdev, ygradg) # can print the cpu version
+        ygradgc = CP.apply_preserve_axes(cdev, ygradg) # can print the cpu version
         # ygradgc.P .- ygrad.P
         # ygradgc.Ms
     end
@@ -95,33 +100,38 @@ end
 @testset "neg_logden_obs Matrix" begin
     is = repeat(axes(θP_true, 1)', n_site)
     θvec = CA.ComponentVector(P = θP_true, Ms = θMs_true)
-    xPM = (S1 = CA.getdata(xP[:S1,:])', S2 = CA.getdata(xP[:S2,:])')
+    xPM = (S1 = CA.getdata(xP[:S1, :])', S2 = CA.getdata(xP[:S2, :])')
     #θ = hcat(θP_true[is], θMs_true')
     intθ1 = get_concrete(ComponentArrayInterpreter(vcat(θP_true, θMs_true[:, 1])))
     #θpos = get_positions(intθ1)
     intθ = get_concrete(ComponentArrayInterpreter((n_site,), intθ1))
-    fcost = (θvec, xPM, y_o, y_unc) -> begin
-        θ = hcat(CA.getdata(θvec.P[is]), CA.getdata(θvec.Ms'))
-        y = HVI.DoubleMM.f_doubleMM(θ, xPM, intθ)
-        #y = HVI.DoubleMM.f_doubleMM(θ, xPM, θpos)
-        fneglogden(y_o, y', y_unc)
+    fcost = let is = is, intθ = intθ, fneglogden=fneglogden
+        (θvec, xPM, y_o, y_unc) -> begin
+            θ = hcat(CA.getdata(θvec.P[is]), CA.getdata(θvec.Ms'))
+            y = CP.DoubleMM.f_doubleMM(θ, xPM, intθ)
+            #y = CP.DoubleMM.f_doubleMM(θ, xPM, θpos)
+            res = fneglogden(y_o, y', y_unc)
+            res
+        end
     end
-    cost = fcost(θvec, xPM, y_o, y_unc)
+    #fcost = CP.tmp_fcost(is, intθ, fneglogden)
+    cost = @inferred fcost(θvec, xPM, y_o, y_unc)
+    # @descend_code_warntype fcost(θvec, xPM, y_o, y_unc)
     ygrad = Zygote.gradient(θv -> fcost(θv, xPM, y_o, y_unc), θvec)[1]
     if gdev isa MLDataDevices.AbstractGPUDevice
         # θg = gdev(θ)
         # xPMg = gdev(xPM)
-        # yg = HVI.DoubleMM.f_doubleMM(θg, xPMg, intθ);
-        θvecg = gdev(θvec);
+        # yg = CP.DoubleMM.f_doubleMM(θg, xPMg, intθ);
+        θvecg = gdev(θvec)
         xPMg = gdev(xPM)
-        y_og = gdev(y_o);
+        y_og = gdev(y_o)
         y_uncg = gdev(y_unc)
         costg = fcost(θvecg, xPMg, y_og, y_uncg)
         @test costg ≈ cost
         ygradg = Zygote.gradient(θv -> fcost(θv, xPMg, y_og, y_uncg), θvecg)[1]; # errors without ";"
         @test ygradg isa CA.ComponentArray
         @test CA.getdata(ygradg) isa GPUArraysCore.AbstractGPUArray
-        ygradgc = HVI.apply_preserve_axes(cdev, ygradg) # can print the cpu version
+        ygradgc = CP.apply_preserve_axes(cdev, ygradg) # can print the cpu version
         # ygradgc.P .- ygrad.P
         # ygradgc.Ms
     end
@@ -130,24 +140,33 @@ end
 @testset "loss_g" begin
     g, ϕg0 = get_hybridproblem_MLapplicator(rng, prob; scenario)
     (; transP, transM) = get_hybridproblem_transforms(prob; scenario)
+    n_site, n_batch = get_hybridproblem_n_site_and_batch(prob; scenario)
+    transMs = StackedArray(transM, n_batch)
+    xM_batch = xM[:, 1:n_batch]
+    θMs_true_tb = θMs_true[:, 1:20]'
 
-    function loss_g(ϕg, x, g, transM)
-        # @show first(x,5)
-        # @show first(ϕg,5)
-        ζMs = g(x, ϕg) # predict the parameters on unconstrained space
-        # @show first(ζMs,5)
-        θMs = reduce(hcat, map(transM, eachcol(ζMs))) # transform each column
-        loss = sum(abs2, θMs .- θMs_true)
-        return loss, θMs
+    loss_g = let θMs_true_tb = θMs_true_tb
+        function loss_g_inner(ϕg, x, g, transMs)
+            # @show first(x,5)
+            # @show first(ϕg,5)
+            ζMs = g(x, ϕg)' # predict the parameters on unconstrained space
+            # need to transpose, so that each parameter is a column -> for  extend_stacked_nrow
+            θMs = transMs(ζMs)
+            # @show first(ζMs,5)
+            #θMs = reduce(hcat, map(transM, eachcol(ζMs_parfirst))) # transform each column
+            loss = sum(abs2, θMs .- θMs_true_tb)
+            return loss, θMs
+        end
     end
-    l = loss_g(ϕg0, xM, g, transM)
+    l = @inferred loss_g(ϕg0, xM_batch, g, transMs)
     @test isfinite(l[1])
-    Zygote.gradient(ϕg -> loss_g(ϕg, xM, g, transM)[1], ϕg0)
+    Zygote.gradient(ϕg -> loss_g(ϕg, xM_batch, g, transMs)[1], ϕg0)
     #
     # actual optimization (do not need to test each time)
     () -> begin
         #histogram(ϕg0)
-        optf = Optimization.OptimizationFunction((ϕg, p) -> loss_g(ϕg, xM, g, transM)[1],
+        optf = Optimization.OptimizationFunction(
+            (ϕg, p) -> loss_g(ϕg, xM_batch, g, transMs)[1],
             Optimization.AutoZygote())
         optprob = Optimization.OptimizationProblem(optf, ϕg0)
         #res = Optimization.solve(optprob, Adam(0.02), callback = callback_loss(100), maxiters = 600);
@@ -156,12 +175,12 @@ end
         ϕg_opt1 = res.u
         #histogram(ϕg_opt1) # all similar magnitude around zero
         #first(ϕg_opt1,5)
-        pred = loss_g(ϕg_opt1, xM, g, transM)
+        pred = loss_g(ϕg_opt1, xM_batch, g, transMs)
         θMs_pred = θMs_pred_1 = pred[2]
-        #scatterplot(vec(θMs_true), vec(θMs_pred))
+        #scatterplot(vec(θMs_true_tb), vec(θMs_pred))
         #@test cor(vec(θMs_true), vec(θMs_pred)) > 0.9
-        @test cor(θMs_true[:, 1], θMs_pred[:, 1]) > 0.9
-        @test cor(θMs_true[:, 2], θMs_pred[:, 2]) > 0.9
+        @test cor(θMs_true_tb[:, 1], θMs_pred[:, 1]) > 0.9
+        @test cor(θMs_true_tb[:, 2], θMs_pred[:, 2]) > 0.9
     end
 end
 
@@ -178,7 +197,7 @@ end
     intϕ = ComponentArrayInterpreter(CA.ComponentVector(
         ϕg = 1:length(ϕg0), ϕP = par_templates.θP))
     p = p0 = vcat(ϕg0,
-        HVI.apply_preserve_axes(inverse(transP), par_templates.θP) .-
+        CP.apply_preserve_axes(inverse(transP), par_templates.θP) .-
         convert(eltype(ϕg0), 0.1))  # slightly disturb θP_true
     #p = p0 = vcat(ϕg_opt1, par_templates.θP);  # almost true
 
@@ -190,15 +209,18 @@ end
     pbm_covars = get_hybridproblem_pbmpar_covars(prob; scenario)
 
     #loss_gf = get_loss_gf(g, transM, f, y_global_o, intϕ; gdev = identity)
-    loss_gf = get_loss_gf(g, transM, transP, f, y_global_o, intϕ; pbm_covars)
-    loss_gf2 = get_loss_gf(g, transM, transP, f2, y_global_o, intϕ; pbm_covars)
-    l1 = loss_gf(p0, first(train_loader)...)[1]
+    loss_gf = get_loss_gf(g, transM, transP, f, y_global_o, intϕ;
+        pbm_covars, n_site_batch = n_batch)
+    loss_gf2 = get_loss_gf(g, transM, transP, f2, y_global_o, intϕ;
+        pbm_covars, n_site_batch = n_site)
+    l1 = @inferred first(loss_gf(p0, first(train_loader)...))
     (xM_batch, xP_batch, y_o_batch, y_unc_batch, i_sites_batch) = first(train_loader)
+    # @usingany Cthulhu
+    # @descend_code_warntype loss_gf(p0, xM_batch, xP_batch, y_o_batch, y_unc_batch, i_sites_batch)
     Zygote.gradient(
-        p0 -> loss_gf(
-            p0, xM_batch, xP_batch, y_o_batch, y_unc_batch, i_sites_batch)[1], CA.getdata(p0))
-
-    optf = Optimization.OptimizationFunction((ϕ, data) -> loss_gf(ϕ, data...)[1],
+        p0 -> first(loss_gf(
+            p0, xM_batch, xP_batch, y_o_batch, y_unc_batch, i_sites_batch)), CA.getdata(p0))
+    optf = Optimization.OptimizationFunction((ϕ, data) -> first(loss_gf(ϕ, data...)),
         Optimization.AutoZygote())
     optprob = OptimizationProblem(optf, CA.getdata(p0), train_loader)
 
@@ -208,27 +230,26 @@ end
 
     l1, y_pred_global, y_pred, θMs_pred, θP_pred = loss_gf2(res.u, train_loader.data...)
     #l1, y_pred_global, y_pred, θMs_pred = loss_gf(p0, xM, xP, y_o, y_unc);
-    θMs_pred = CA.ComponentArray(θMs_pred, CA.getaxes(θMs_true))
+    θMs_pred = CA.ComponentArray(θMs_pred, CA.getaxes(θMs_true'))
     #TODO @test isapprox(par_templates.θP, intϕ(res.u).ϕP, rtol = 0.15)
     #@test cor(vec(θMs_true), vec(θMs_pred)) > 0.8
-    @test cor(θMs_true[:, 1], θMs_pred[:, 1]) > 0.8
-    @test cor(θMs_true[:, 2], θMs_pred[:, 2]) > 0.8
+    @test cor(θMs_true'[:, 1], θMs_pred[:, 1]) > 0.8
+    @test cor(θMs_true'[:, 2], θMs_pred[:, 2]) > 0.8
     # started from low values -> increased but not too much above true values
     @test all(transP(intϕ(p0).ϕP) .< θP_pred .< (1.2 .* par_templates.θP))
 
     () -> begin
         #@usingany UnicodePlots
-        scatterplot(vec(θMs_true), vec(θMs_pred))
-        scatterplot(θMs_true[1, :], θMs_pred[1, :])
-        scatterplot(θMs_true[2, :], θMs_pred[2, :])
-        scatterplot(log.(vec(θMs_true)), log.(vec(θMs_pred)))
+        scatterplot(θMs_true'[:,1], θMs_pred[:,1])
+        scatterplot(θMs_true'[:,2], θMs_pred[:,2])
+        scatterplot(log.(vec(θMs_true')), log.(vec(θMs_pred)))
         scatterplot(vec(y_pred), vec(y_o))
         hcat(par_templates.θP, intϕ(p0).ϕP, intϕ(res.u).ϕP, transP(intϕ(p0).ϕP), θP_pred)
     end
 end
 
 if gdev isa MLDataDevices.AbstractGPUDevice
-    scenario = (:use_Flux,)
+    scenario = Val((:use_Flux,:use_gpu))
     g, ϕg0 = get_hybridproblem_MLapplicator(rng, prob; scenario)
     ϕg0_gpu = gdev(ϕg0)
     xM_gpu = gdev(xM)

--- a/test/test_elbo.jl
+++ b/test/test_elbo.jl
@@ -31,12 +31,12 @@ scenario = (:default,)
 test_scenario = (scenario) -> begin
     FT = get_hybridproblem_float_type(prob; scenario)
     par_templates = get_hybridproblem_par_templates(prob; scenario)
+    int_P, int_M = map(ComponentArrayInterpreter, par_templates)
     pbm_covars = get_hybridproblem_pbmpar_covars(prob; scenario)
     pbm_covar_indices = CP.get_pbm_covar_indices(par_templates.θP, pbm_covars)
 
 
     #θsite_true = get_hybridproblem_par_templates(prob; scenario)
-    n_covar = 5
     n_site, n_batch = get_hybridproblem_n_site_and_batch(prob; scenario)
     (; xM, θP_true, θMs_true, xP, y_global_true, y_true, y_global_o, y_o, y_unc
     ) = gen_hybridproblem_synthetic(rng, prob; scenario);
@@ -45,7 +45,7 @@ test_scenario = (scenario) -> begin
     f = get_hybridproblem_PBmodel(prob; scenario, use_all_sites = false)
     f_pred = get_hybridproblem_PBmodel(prob; scenario, use_all_sites = true)
 
-    n_θM, n_θP = values(map(length, get_hybridproblem_par_templates(prob; scenario)))
+    n_θM, n_θP = values(map(length, par_templates))
 
 
     py = neg_logden_indep_normal
@@ -60,6 +60,7 @@ test_scenario = (scenario) -> begin
     (; ϕ, transPMs_batch, interpreters, get_transPMs, get_ca_int_PMs) = init_hybrid_params(
         θP_true, θMs_true[:, 1], cor_ends, ϕg0, n_batch; transP, transM);
     ϕ_ini = ϕ
+    transform_tools = CP.setup_transform_ζ(transP, transM, interpreters.PMs)
 
     if ggdev isa MLDataDevices.AbstractGPUDevice
         scenario_flux = (scenario..., :use_Flux, :use_gpu)
@@ -67,77 +68,122 @@ test_scenario = (scenario) -> begin
         g_gpu = ggdev(g_flux)
     end;
 
-    @testset "generate_ζ" begin
+    ζs, σ = CP.generate_ζ(
+        rng, g, ϕ_ini, xM[:, 1:n_batch];
+        n_MC = 8, cor_ends, pbm_covar_indices, 
+        int_unc = interpreters.unc, int_μP_ϕg_unc=interpreters.μP_ϕg_unc, int_PMs=interpreters.PMs)
+
+    @testset "generate_ζ $(last(scenario))" begin
         # xMtest = vcat(xM, xM[1:1,:])
         # ζ, σ = CP.generate_ζ(
         #     rng, g, ϕ_ini, xMtest[:, 1:n_batch], map(get_concrete, interpreters);
         #     n_MC = 8, cor_ends, pbm_covar_indices)
-        ζ, σ = CP.generate_ζ(
-            rng, g, ϕ_ini, xM[:, 1:n_batch], map(get_concrete, interpreters);
-            n_MC = 8, cor_ends, pbm_covar_indices)
-        @test ζ isa Matrix
+        @test ζs isa Matrix
         gr = Zygote.gradient(
             # ϕ -> sum(CP.generate_ζ(
             #     rng, g, ϕ, xMtest[:, 1:n_batch], map(get_concrete, interpreters);
             #     n_MC = 8, cor_ends, pbm_covar_indices)[1]),
             ϕ -> sum(CP.generate_ζ(
-                rng, g, ϕ, xM[:, 1:n_batch], map(get_concrete, interpreters);
-                n_MC = 8, cor_ends, pbm_covar_indices)[1]),
+                rng, g, ϕ, xM[:, 1:n_batch];
+                n_MC = 8, cor_ends, pbm_covar_indices,
+                int_unc = interpreters.unc, int_μP_ϕg_unc=interpreters.μP_ϕg_unc, int_PMs=interpreters.PMs
+                )[1]),
             CA.getdata(ϕ_ini))
         @test gr[1] isa Vector
     end;
 
-
     if ggdev isa MLDataDevices.AbstractGPUDevice
-        @testset "generate_ζ gpu" begin
+        @testset "generate_ζ gpu $(last(scenario))" begin
             ϕ = ggdev(CA.getdata(ϕ_ini))
             @test g_gpu.μ isa GPUArraysCore.AbstractGPUArray
             xMg_batch = ggdev(xM[:, 1:n_batch])
             ζ, σ = CP.generate_ζ(
-                rng, g_gpu, ϕ, xMg_batch, map(get_concrete, interpreters);
-                n_MC = 8, cor_ends, pbm_covar_indices)
+                rng, g_gpu, ϕ, xMg_batch;
+                n_MC = 8, cor_ends, pbm_covar_indices,
+                int_unc = interpreters.unc, int_μP_ϕg_unc=interpreters.μP_ϕg_unc, int_PMs=interpreters.PMs
+                )
             @test ζ isa GPUArraysCore.AbstractGPUMatrix
             @test eltype(ζ) == FT
             gr = Zygote.gradient(
                 ϕ -> sum(CP.generate_ζ(
-                    rng, g_gpu, ϕ, xMg_batch, map(get_concrete, interpreters);
-                    n_MC = 8, cor_ends, pbm_covar_indices)[1]),
+                    rng, g_gpu, ϕ, xMg_batch;
+                    n_MC = 8, cor_ends, pbm_covar_indices,
+                    int_unc = interpreters.unc, int_μP_ϕg_unc=interpreters.μP_ϕg_unc, int_PMs=interpreters.PMs
+                    )[1]),
                 ϕ)
             @test gr[1] isa GPUArraysCore.AbstractGPUVector
         end
     end
 
-    @testset "neg_elbo_gtf cpu" begin
+    @testset "transform ζs" begin
+        n_MC = 3 #size(ζs,2)
+        # reorder Ms columns so that first parameter of all sites is first
+        # # transforming entire parameter set across n_MC most efficient but
+        # # does not yield logdetjac
+        # intm_PMs_gen = get_ca_int_PMs(n_batch);
+        # pos_intm_PMs = get_positions(intm_PMs_gen)
+        # function trans_ζs_crossMC(ζs::AbstractMatrix, pos_intm_PMs::NamedTuple; n_MC = size(ζs,2))
+        #     ζstMs = ζs'[1:n_MC, pos_intm_PMs.Ms'] # n_MC x n_site_batch x n_par
+        #     ζstP = ζs'[1:n_MC, pos_intm_PMs.P] # n_MC x n_par
+        #     transPM = extend_stacked_nrow(transP, n_MC)
+        #     θsP = reshape(transPM(vec(ζstP)), size(ζstP))
+        #     transMM = extend_stacked_nrow(transM, n_MC * n_batch)
+        #     θsMs = reshape(transMM(vec(ζstMs)), size(ζstMs))
+        #     (θsP, θsMs)            
+        # end
+        # (θsP, θsMs) = trans_ζs(ζs, pos_intm_PMs; n_MC)
+        # @test size(θsP) == (n_MC, n_θP)
+        # @test size(θsMs) == (n_MC, n_batch, n_θM)
+        # map by rows
+        ζ = ζs[:,1]
+        θP, θMs, logjac = CP.transform_ζ(ζ, transP, transM, interpreters.PMs)
+        @test size(θP) == (n_θP,)
+        @test size(θMs) == (n_batch, n_θM)
+        if ggdev isa MLDataDevices.AbstractGPUDevice
+            ζdev = ggdev(ζ)
+            θP, θMs, logjac = CP.transform_ζ(ζdev, transP, transM, interpreters.PMs)
+            _transform_tools = CP.setup_transform_ζ(
+                transP, transM, interpreters.PMs)
+            gr = Zygote.gradient(ζdev) do ζdev
+                θP, θMs, logjac = CP.transform_ζ(ζdev, _transform_tools...)
+                sum(θP) + sum(θMs) + logjac
+            end
+            @test eltype(gr[1]) == eltype(ζ)
+        end
+    end
+
+
+    @testset "neg_elbo_gtf cpu $(last(scenario))" begin
         i_sites = 1:n_batch
-        cost = neg_elbo_gtf(rng, ϕ_ini, g, transPMs_batch, f, py,
+        cost = neg_elbo_gtf(rng, ϕ_ini, g, f, py,
             xM[:, i_sites], xP[:,i_sites], y_o[:, i_sites], y_unc[:, i_sites], i_sites,
-            map(get_concrete, interpreters);
+            map(get_concrete, interpreters), transform_tools;
             cor_ends, pbm_covar_indices)
         @test cost isa Float64
         gr = Zygote.gradient(
-            ϕ -> neg_elbo_gtf(rng, ϕ, g, transPMs_batch, f, py,
+            ϕ -> neg_elbo_gtf(rng, ϕ, g, f, py,
                 xM[:, i_sites], xP[:,i_sites], y_o[:, i_sites], y_unc[:, i_sites], i_sites,
-                map(get_concrete, interpreters);
+                map(get_concrete, interpreters), transform_tools;
                 cor_ends, pbm_covar_indices),
             CA.getdata(ϕ_ini))
         @test gr[1] isa Vector
     end;
 
     if ggdev isa MLDataDevices.AbstractGPUDevice
-        @testset "neg_elbo_gtf gpu" begin
+        @testset "neg_elbo_gtf gpu $(last(scenario))" begin
             i_sites = 1:n_batch
             ϕ = ggdev(CA.getdata(ϕ_ini))
             xMg_batch = ggdev(xM[:, i_sites])
             xP_batch = xP[:,i_sites] # used in f which runs on CPU
-            cost = neg_elbo_gtf(rng, ϕ, g_gpu, transPMs_batch, f, py,
+            cost = neg_elbo_gtf(rng, ϕ, g_gpu, f, py,
                 xMg_batch, xP_batch, y_o[:, i_sites], y_unc[:, i_sites], i_sites,
-                map(get_concrete, interpreters);
+                map(get_concrete, interpreters), transform_tools;
                 n_MC = 3, cor_ends, pbm_covar_indices)
             @test cost isa Float64
             gr = Zygote.gradient(
-                ϕ -> neg_elbo_gtf(rng, ϕ, g_gpu, transPMs_batch, f, py,
+                ϕ -> neg_elbo_gtf(rng, ϕ, g_gpu, f, py,
                     xMg_batch, xP_batch, y_o[:, i_sites], y_unc[:, i_sites], i_sites,
-                    map(get_concrete, interpreters);
+                    map(get_concrete, interpreters), transform_tools;
                     n_MC = 3, cor_ends, pbm_covar_indices),
                 ϕ)
             @test gr[1] isa GPUArraysCore.AbstractGPUVector
@@ -145,29 +191,51 @@ test_scenario = (scenario) -> begin
         end
     end
 
-    @testset "predict_gf cpu" begin
-        n_sample_pred = n_site = 200
-        intm_PMs_gen = get_ca_int_PMs(n_site)
-        trans_PMs_gen = get_transPMs(n_site)
-        @test length(intm_PMs_gen) == 402
-        @test trans_PMs_gen.length_in == 402
-        (; θ, y) = predict_gf(rng, g, f_pred, ϕ_ini, xM, xP, map(get_concrete, interpreters);
-            get_transPMs, get_ca_int_PMs, n_sample_pred, cor_ends, pbm_covar_indices)
-        @test θ isa CA.ComponentMatrix
-        @test θ[:, 1].P.r0 > 0
+    n_sample_pred = 200
+    int_PMs = get_concrete(CP.construct_int_PMs_parfirst(int_P, int_M, size(xP,2)))
+    intm_PMs = get_concrete(ComponentArrayInterpreter(int_PMs, (n_sample_pred,)))
+    int_PMst = get_concrete(CP.construct_int_PMs_sitefirst(int_P, int_M, size(xP,2)))
+    intm_PMst = get_concrete(ComponentArrayInterpreter(int_PMst, (n_sample_pred,)))
+    int_unc = get_concrete(interpreters.unc)
+
+    @testset "predict_gf cpu $(last(scenario))" begin
+        # intm_PMs_gen = get_ca_int_PMs(n_site)
+        # trans_PMs_gen = get_transPMs(n_site)
+        # @test length(intm_PMs_gen) == 402
+        # @test trans_PMs_gen.length_in == 402
+        (; θs, y, intm_PMst) = 
+        #Cthulhu.@descend_code_warntype (
+        #@inferred (
+        predict_gf(rng, g, f_pred, ϕ_ini, xM, xP, map(get_concrete, interpreters),
+            int_P, int_M;
+            #get_transPMs, 
+            transP, transM, 
+            get_ca_int_PMs, n_sample_pred, cor_ends, pbm_covar_indices,
+            int_PMs, int_PMst, intm_PMst, int_unc
+            )
+        #)
+        @test θs isa CA.ComponentMatrix
+        @test θs[:,1].P.r0 > 0
+        @test size(θs,2) == n_sample_pred
         @test y isa Array
         @test size(y) == (size(y_o)..., n_sample_pred)
     end
 
     if ggdev isa MLDataDevices.AbstractGPUDevice
-        @testset "predict_gf gpu" begin
+        @testset "predict_gf gpu $(last(scenario))" begin
             n_sample_pred = 200
-            ϕ = ggdev(CA.getdata(ϕ_ini))
+            ϕ_ini_g = ggdev(CA.getdata(ϕ_ini))
             xMg = ggdev(xM)
-            (; θ, y) = predict_gf(rng, g_gpu, f_pred, ϕ, xMg, xP, map(get_concrete, interpreters);
-                get_transPMs, get_ca_int_PMs, n_sample_pred, cor_ends, pbm_covar_indices)
-            @test θ isa CA.ComponentMatrix # only ML parameters are on gpu
-            @test θ[:, 1].P.r0 > 0
+            (; θs, y, intm_PMst) = predict_gf(rng, g_gpu, f_pred, ϕ_ini_g, xMg, xP, map(get_concrete, interpreters),
+            int_P, int_M;
+            #get_transPMs, 
+            transP, transM, 
+            get_ca_int_PMs, n_sample_pred, cor_ends, pbm_covar_indices,
+            int_PMs, int_PMst, intm_PMst, int_unc
+            )
+            @test θs isa CA.ComponentMatrix # only ML parameters are on gpu
+            @test θs[:,1].P.r0 > 0
+            @test size(θs,2) == n_sample_pred
             @test y isa Array
             @test size(y) == (size(y_o)..., n_sample_pred)
         end

--- a/test/test_elbo.jl
+++ b/test/test_elbo.jl
@@ -20,14 +20,12 @@ using Flux
 
 ggdev = gpu_device()
 
-
 #CUDA.device!(4)
 rng = StableRNG(111)
 
 const prob = DoubleMM.DoubleMMCase()
 scenario = Val((:default,))
 #scenario = Val((:covarK2,))
-
 
 test_scenario = (scenario) -> begin
     FT = get_hybridproblem_float_type(prob; scenario)
@@ -36,18 +34,18 @@ test_scenario = (scenario) -> begin
     pbm_covars = get_hybridproblem_pbmpar_covars(prob; scenario)
     pbm_covar_indices = CP.get_pbm_covar_indices(par_templates.θP, pbm_covars)
 
-
     #θsite_true = get_hybridproblem_par_templates(prob; scenario)
     n_site, n_batch = get_hybridproblem_n_site_and_batch(prob; scenario)
-    (; xM, θP_true, θMs_true, xP, y_global_true, y_true, y_global_o, y_o, y_unc
-    ) = gen_hybridproblem_synthetic(rng, prob; scenario);
+    (; xM, θP_true, θMs_true, xP, y_global_true, y_true, y_global_o, y_o,
+        y_unc) = gen_hybridproblem_synthetic(rng, prob; scenario)
 
-    g, ϕg0 = @inferred get_hybridproblem_MLapplicator(prob; scenario);
-    f = get_hybridproblem_PBmodel(prob; scenario, use_all_sites = false)
-    f_pred = get_hybridproblem_PBmodel(prob; scenario, use_all_sites = true)
+    # TODO
+    #g, ϕg0 = @inferred get_hybridproblem_MLapplicator(prob; scenario);
+    g, ϕg0 = get_hybridproblem_MLapplicator(prob; scenario)
+    f = get_hybridproblem_PBmodel(prob; scenario, use_all_sites=false)
+    f_pred = get_hybridproblem_PBmodel(prob; scenario, use_all_sites=true)
 
     n_θM, n_θP = values(map(length, par_templates))
-
 
     py = neg_logden_indep_normal
 
@@ -60,27 +58,31 @@ test_scenario = (scenario) -> begin
     ϕunc0 = init_hybrid_ϕunc(cor_ends, zero(FT))
     hpints = HybridProblemInterpreters(prob; scenario)
     (; ϕ, transPMs_batch, interpreters, get_transPMs, get_ca_int_PMs) = init_hybrid_params(
-        θP_true, θMs_true[:, 1], cor_ends, ϕg0, hpints; transP, transM);
+        θP_true, θMs_true[:, 1], cor_ends, ϕg0, hpints; transP, transM)
+    int_unc = interpreters.unc
+    int_μP_ϕg_unc = interpreters.μP_ϕg_unc
+
     # @descend_code_warntype init_hybrid_params(θP_true, θMs_true[:, 1], cor_ends, ϕg0, n_batch; transP, transM)
     # @descend_code_warntype CA.ComponentVector(nt)
     ϕ_ini = ϕ
-    transform_tools = @inferred CP.setup_transform_ζ(transP, transM, get_int_PMst_batch(hpints))
+    transform_tools = nothing # TODO remove
+    # transform_tools = @inferred CP.setup_transform_ζ(
+    #     transP, transM, get_int_PMst_batch(hpints))
     int_PMs = get_int_PMst_batch(hpints)
 
     if ggdev isa MLDataDevices.AbstractGPUDevice
         scenario_flux = Val((CP._val_value(scenario)..., :use_Flux, :use_gpu))
-        g_flux, ϕg0_flux_cpu = get_hybridproblem_MLapplicator(prob; scenario = scenario_flux)
+        g_flux, ϕg0_flux_cpu = get_hybridproblem_MLapplicator(
+            prob; scenario=scenario_flux)
         g_gpu = ggdev(g_flux)
-    end;
+    end
 
-
-    ζs, σ = @inferred (
+    ζsP, ζsMs, σ = @inferred (
     # @descend_code_warntype (
         CP.generate_ζ(
         rng, g, ϕ_ini, xM[:, 1:n_batch];
-        n_MC, cor_ends, pbm_covar_indices, 
-        int_unc = interpreters.unc, int_μP_ϕg_unc=interpreters.μP_ϕg_unc, 
-        int_PMs)
+        n_MC, cor_ends, pbm_covar_indices,
+        int_unc=interpreters.unc, int_μP_ϕg_unc=interpreters.μP_ϕg_unc)
     )
 
     @testset "generate_ζ $(last(CP._val_value(scenario)))" begin
@@ -88,49 +90,52 @@ test_scenario = (scenario) -> begin
         # ζ, σ = CP.generate_ζ(
         #     rng, g, ϕ_ini, xMtest[:, 1:n_batch], map(get_concrete, interpreters);
         #     n_MC = 8, cor_ends, pbm_covar_indices)
-        @test ζs isa AbstractMatrix
-        @test size(ζs) == (n_MC, length(int_PMs))
+        @test ζsP isa AbstractMatrix
+        @test ζsMs isa AbstractArray
+        @test size(ζsP) == (n_θP, n_MC)
+        @test size(ζsMs) == (n_batch, n_θM, n_MC)
         gr = Zygote.gradient(
-            # ϕ -> sum(CP.generate_ζ(
-            #     rng, g, ϕ, xMtest[:, 1:n_batch], map(get_concrete, interpreters);
-            #     n_MC = 8, cor_ends, pbm_covar_indices)[1]),
-            ϕ -> sum(first(CP.generate_ζ(
-                rng, g, ϕ, xM[:, 1:n_batch];
-                n_MC = 8, cor_ends, pbm_covar_indices,
-                int_unc = interpreters.unc, int_μP_ϕg_unc=interpreters.μP_ϕg_unc, int_PMs
-                ))),
-            CA.getdata(ϕ_ini))
+            ϕ -> begin
+                ζsP, ζsMs, σ = CP.generate_ζ(
+                    rng, g, ϕ, xM[:, 1:n_batch];
+                    n_MC=8, cor_ends, pbm_covar_indices,
+                    int_unc=interpreters.unc, int_μP_ϕg_unc=interpreters.μP_ϕg_unc)
+                sum(ζsP) + sum(ζsMs) + sum(σ)
+            end, CA.getdata(ϕ_ini))
         @test gr[1] isa Vector
-    end;
+    end
 
     if ggdev isa MLDataDevices.AbstractGPUDevice
         @testset "generate_ζ gpu $(last(CP._val_value(scenario)))" begin
             ϕ = ggdev(CA.getdata(ϕ_ini))
             @test g_gpu.μ isa GPUArraysCore.AbstractGPUArray
             xMg_batch = ggdev(xM[:, 1:n_batch])
-            ζ, σ = @inferred (
-                # @descend_code_warntype (
+            ζsP_d, ζsMs_d, σ_d = @inferred (
+            # @descend_code_warntype (
                 CP.generate_ζ(
                 rng, g_gpu, ϕ, xMg_batch;
                 n_MC, cor_ends, pbm_covar_indices,
-                int_unc = interpreters.unc, int_μP_ϕg_unc=interpreters.μP_ϕg_unc, int_PMs
-                ))
-            @test ζ isa Union{GPUArraysCore.AbstractGPUMatrix, 
-                LinearAlgebra.Adjoint{FT, <: GPUArraysCore.AbstractGPUMatrix}} 
-            @test eltype(ζ) == FT
-            @test size(ζs) == (n_MC, length(int_PMs))
+                int_unc=interpreters.unc, int_μP_ϕg_unc=interpreters.μP_ϕg_unc))
+            @test ζsP_d isa Union{GPUArraysCore.AbstractGPUMatrix,
+                LinearAlgebra.Adjoint{FT,<:GPUArraysCore.AbstractGPUMatrix}}
+            @test ζsMs_d isa Union{GPUArraysCore.AbstractGPUArray,
+                LinearAlgebra.Adjoint{FT,<:GPUArraysCore.AbstractGPUArray}}
+            @test eltype(ζsP_d) == eltype(ζsMs_d) == FT
+            @test size(ζsP_d) == (n_θP, n_MC)
+            @test size(ζsMs_d) == (n_batch, n_θM, n_MC)
             gr = Zygote.gradient(
-                ϕ -> sum(first(CP.generate_ζ(
-                    rng, g_gpu, ϕ, xMg_batch;
-                    n_MC, cor_ends, pbm_covar_indices,
-                    int_unc = interpreters.unc, int_μP_ϕg_unc=interpreters.μP_ϕg_unc, int_PMs
-                    ))),
-                ϕ)
+                ϕ -> begin
+                    ζsP, ζsMs, σ = CP.generate_ζ(
+                        rng, g_gpu, ϕ, xMg_batch;
+                        n_MC, cor_ends, pbm_covar_indices,
+                        int_unc=interpreters.unc, int_μP_ϕg_unc=interpreters.μP_ϕg_unc)
+                    sum(ζsP) + sum(ζsMs) + sum(σ)
+                end, CA.getdata(ϕ))
             @test gr[1] isa GPUArraysCore.AbstractGPUVector
         end
     end
 
-    @testset "transform ζs" begin
+    @testset "transform_and_logjac_ζ $(last(CP._val_value(scenario)))" begin
         # reorder Ms columns so that first parameter of all sites is first
         # # transforming entire parameter set across n_MC most efficient but
         # # does not yield logdetjac
@@ -149,115 +154,144 @@ test_scenario = (scenario) -> begin
         # @test size(θsP) == (n_MC, n_θP)
         # @test size(θsMs) == (n_MC, n_batch, n_θM)
         # map by rows
-        ζ = ζs[1,:]
-        θP, θMs, logjac = CP.transform_ζ(ζ, transP, transM, int_PMs)
+        ζP, ζMs = ζsP[:, 1], ζsMs[:, :, 1]
+        n_site_batch = size(ζMs, 1)
+        transMs = StackedArray(transM, n_site_batch)
+        θP, θMs, logjac = @inferred CP.transform_and_logjac_ζ(ζP, ζMs; transP, transMs)
         @test size(θP) == (n_θP,)
-        @test size(θMs) == (n_batch, n_θM)
+        @test size(θMs) == (n_site_batch, n_θM)
+        @test θP == transP(ζP)
+        @test θMs[1, :] == transM(ζMs[1, :])
+        @test θMs[end, :] == transM(ζMs[end, :])
         if ggdev isa MLDataDevices.AbstractGPUDevice
-            ζdev = ggdev(ζ)
-            θP, θMs, logjac = @inferred CP.transform_ζ(ζdev, transP, transM, int_PMs)
-            _transform_tools = @inferred CP.setup_transform_ζ(
-                transP, transM, int_PMs)
-            gr = Zygote.gradient(ζdev) do ζdev
-                θP, θMs, logjac = CP.transform_ζ(ζdev, _transform_tools...)
+            ζPdev, ζMsdev = ggdev.((ζP, ζMs))
+            θP, θMs, logjac = @inferred CP.transform_and_logjac_ζ(
+                ζPdev, ζMsdev; transP, transMs)
+            @test size(θP) == (n_θP,)
+            @test size(θMs) == (n_site_batch, n_θM)
+            gr = Zygote.gradient(ζPdev, ζMsdev) do ζPdev, ζMsdev
+                θP, θMs, logjac = CP.transform_and_logjac_ζ(ζPdev, ζMsdev; transP, transMs)
                 sum(θP) + sum(θMs) + logjac
-            end;
-            @test eltype(gr[1]) == eltype(ζ)
+            end
+            @test eltype(gr[1]) == eltype(ζPdev)
+            @test eltype(gr[2]) == eltype(ζMsdev)
         end
     end
 
+    @testset "transform_ζs $(last(CP._val_value(scenario)))" begin
+        n_site_batch, _, n_MC = size(ζsMs)
+        trans_mP = StackedArray(transP, n_MC)
+        trans_mMs = StackedArray(transM, n_MC * n_site_batch)
+        θsP, θsMs = @inferred CP.transform_ζs(ζsP, ζsMs; trans_mP, trans_mMs)
+        @test size(θsP) == (n_θP, n_MC)
+        @test size(θsMs) == (n_site_batch, n_θM, n_MC)
+        @test θsP[:, 1] == transP(ζsP[:, 1])
+        @test θsP[:, end] == transP(ζsP[:, end])
+        @test θsMs[1, :, 1] == transM(ζsMs[1, :, 1]) # first parameter
+        @test θsMs[end, :, 1] == transM(ζsMs[end, :, 1])
+        @test θsMs[1, :, end] == transM(ζsMs[1, :, end]) # last parameter
+        @test θsMs[end, :, end] == transM(ζsMs[end, :, end])
+        if ggdev isa MLDataDevices.AbstractGPUDevice
+            ζsPdev, ζsMsdev = ggdev.((ζsP, ζsMs))
+            #trans_mP(ζsPdev)
+            θsP, θsMs = @inferred CP.transform_ζs(ζsPdev, ζsMsdev; trans_mP, trans_mMs)
+            gr = Zygote.gradient(ζsPdev, ζsMsdev) do ζsPdev, ζsMsdev
+                θsP, θsMs = CP.transform_ζs(ζsPdev, ζsMsdev; trans_mP, trans_mMs)
+                sum(θsP) + sum(θsMs)
+            end
+            @test eltype(gr[1]) == eltype(ζsPdev)
+            @test eltype(gr[2]) == eltype(ζsMsdev)
+        end
+    end
 
     @testset "neg_elbo_gtf cpu $(last(CP._val_value(scenario)))" begin
         i_sites = 1:n_batch
-        cost = 
-        @inferred (
+        transMs = StackedArray(transM, size(ζsMs, 1))
+        cost = @inferred (
         #@descend_code_warntype (
             neg_elbo_gtf(rng, ϕ_ini, g, f, py,
-            xM[:, i_sites], xP[:,i_sites], y_o[:, i_sites], y_unc[:, i_sites], i_sites,
-            map(get_concrete, interpreters), transform_tools;
-            cor_ends, pbm_covar_indices)
-            )
-        
+            xM[:, i_sites], xP[:, i_sites], y_o[:, i_sites], y_unc[:, i_sites], i_sites;
+            int_unc, int_μP_ϕg_unc,
+            cor_ends, pbm_covar_indices, transP, transMs)
+        )
         @test cost isa Float64
         gr = Zygote.gradient(
             ϕ -> neg_elbo_gtf(rng, ϕ, g, f, py,
-                xM[:, i_sites], xP[:,i_sites], y_o[:, i_sites], y_unc[:, i_sites], i_sites,
-                map(get_concrete, interpreters), transform_tools;
-                cor_ends, pbm_covar_indices),
+                xM[:, i_sites], xP[:, i_sites], y_o[:, i_sites], y_unc[:, i_sites], i_sites;
+                int_unc, int_μP_ϕg_unc,
+                cor_ends, pbm_covar_indices, transP, transMs),
             CA.getdata(ϕ_ini))
         @test gr[1] isa Vector
-    end;
+    end
 
     if ggdev isa MLDataDevices.AbstractGPUDevice
         @testset "neg_elbo_gtf gpu $(last(CP._val_value(scenario)))" begin
             i_sites = 1:n_batch
+            transMs = StackedArray(transM, size(ζsMs, 1))
             ϕ = ggdev(CA.getdata(ϕ_ini))
             xMg_batch = ggdev(xM[:, i_sites])
-            xP_batch = xP[:,i_sites] # used in f which runs on CPU
+            xP_batch = xP[:, i_sites] # used in f which runs on CPU
             cost = @inferred (
-                #@descend_code_warntype (
-                 neg_elbo_gtf(rng, ϕ, g_gpu, f, py,
-                xMg_batch, xP_batch, y_o[:, i_sites], y_unc[:, i_sites], i_sites,
-                map(get_concrete, interpreters), transform_tools;
-                n_MC = 3, cor_ends, pbm_covar_indices)
+            #@descend_code_warntype (
+                neg_elbo_gtf(rng, ϕ, g_gpu, f, py,
+                xMg_batch, xP_batch, y_o[:, i_sites], y_unc[:, i_sites], i_sites;
+                int_unc, int_μP_ϕg_unc,
+                n_MC=3, cor_ends, pbm_covar_indices, transP, transMs)
             )
             @test cost isa Float64
             gr = Zygote.gradient(
                 ϕ -> neg_elbo_gtf(rng, ϕ, g_gpu, f, py,
-                    xMg_batch, xP_batch, y_o[:, i_sites], y_unc[:, i_sites], i_sites,
-                    map(get_concrete, interpreters), transform_tools;
-                    n_MC = 3, cor_ends, pbm_covar_indices),
+                    xMg_batch, xP_batch, y_o[:, i_sites], y_unc[:, i_sites], i_sites;
+                    int_unc, int_μP_ϕg_unc,
+                    n_MC=3, cor_ends, pbm_covar_indices, transP, transMs),
                 ϕ)
             @test gr[1] isa GPUArraysCore.AbstractGPUVector
             @test eltype(gr[1]) == FT
         end
     end
 
-    n_sample_pred = 200
-    int_PMs = get_concrete(CP.construct_int_PMs_parfirst(int_P, int_M, size(xP,2)))
-    intm_PMs = get_concrete(ComponentArrayInterpreter(int_PMs, (n_sample_pred,)))
-    int_PMst = get_concrete(CP.construct_int_PMs_sitefirst(int_P, int_M, size(xP,2)))
-    intm_PMst = get_concrete(ComponentArrayInterpreter(int_PMst, (n_sample_pred,)))
-    int_unc = get_concrete(interpreters.unc)
-
     @testset "predict_gf cpu $(last(CP._val_value(scenario)))" begin
         # intm_PMs_gen = get_ca_int_PMs(n_site)
         # trans_PMs_gen = get_transPMs(n_site)
         # @test length(intm_PMs_gen) == 402
         # @test trans_PMs_gen.length_in == 402
-        (; θs, y, intm_PMst) = 
+        n_sample_pred = 30
+        (; y, θsP, θsMs, entropy_ζ) =
         #Cthulhu.@descend_code_warntype (
-        @inferred (
-        predict_gf(rng, g, f_pred, ϕ_ini, xM, xP, map(get_concrete, interpreters),
-            int_P, int_M;
-            #get_transPMs, 
-            transP, transM, 
-            get_ca_int_PMs, n_sample_pred, cor_ends, pbm_covar_indices,
-            int_PMs, int_PMst, intm_PMst, int_unc
+            @inferred (
+                predict_gf(rng, g, f_pred, ϕ_ini, xM, xP;
+                int_μP_ϕg_unc, int_unc,
+                transP, transM,
+                n_sample_pred, cor_ends, pbm_covar_indices)
             )
-        )
-        @test θs isa CA.ComponentMatrix
-        @test θs[:,1].P.r0 > 0
-        @test size(θs,2) == n_sample_pred
+        @test θsP isa AbstractMatrix
+        @test θsMs isa AbstractArray{T,3} where {T}
+        int_mP = ComponentArrayInterpreter(int_P, (size(θsP, 2),))
+        θsPc = int_mP(θsP)
+        @test all(θsPc[:r0, :] .> 0)
         @test y isa Array
         @test size(y) == (size(y_o)..., n_sample_pred)
     end
 
     if ggdev isa MLDataDevices.AbstractGPUDevice
         @testset "predict_gf gpu $(last(CP._val_value(scenario)))" begin
-            n_sample_pred = 200
+            n_sample_pred = 32
             ϕ_ini_g = ggdev(CA.getdata(ϕ_ini))
             xMg = ggdev(xM)
-            (; θs, y, intm_PMst) = predict_gf(rng, g_gpu, f_pred, ϕ_ini_g, xMg, xP, map(get_concrete, interpreters),
-            int_P, int_M;
-            #get_transPMs, 
-            transP, transM, 
-            get_ca_int_PMs, n_sample_pred, cor_ends, pbm_covar_indices,
-            int_PMs, int_PMst, intm_PMst, int_unc
-            )
-            @test θs isa CA.ComponentMatrix # only ML parameters are on gpu
-            @test θs[:,1].P.r0 > 0
-            @test size(θs,2) == n_sample_pred
+            n_sample_pred = 30
+            (; y, θsP, θsMs, entropy_ζ) =
+            #Cthulhu.@descend_code_warntype (
+                @inferred (
+                    predict_gf(rng, g_gpu, f_pred, ϕ_ini_g, xMg, xP;
+                    int_μP_ϕg_unc, int_unc,
+                    transP, transM,
+                    n_sample_pred, cor_ends, pbm_covar_indices)
+                )
+            @test θsP isa AbstractMatrix
+            @test θsMs isa AbstractArray{T,3} where {T}
+            int_mP = ComponentArrayInterpreter(int_P, (size(θsP, 2),))
+            θsPc = int_mP(θsP)
+            @test all(θsPc[:r0, :] .> 0)
             @test y isa Array
             @test size(y) == (size(y_o)..., n_sample_pred)
         end
@@ -284,13 +318,10 @@ test_scenario = (scenario) -> begin
         #     @test y isa GPUArraysCore.AbstractGPUArray
         #     @test size(y) == (size(y_o)..., n_sample_pred)
         # end
-
-    end
+    end # if ggdev
 end # test_scenario
 
-test_scenario((:default,))
+test_scenario(Val((:default,)))
 
 # with providing process parameter as additional covariate
-test_scenario((:covarK2,))
-
-
+test_scenario(Val((:covarK2,)))

--- a/test/test_elbo.jl
+++ b/test/test_elbo.jl
@@ -1,4 +1,5 @@
 #using LinearAlgebra, BlockDiagonals
+using LinearAlgebra
 
 using Test
 using HybridVariationalInference
@@ -24,8 +25,8 @@ ggdev = gpu_device()
 rng = StableRNG(111)
 
 const prob = DoubleMM.DoubleMMCase()
-scenario = (:default,)
-#scenario = (:covarK2,)
+scenario = Val((:default,))
+#scenario = Val((:covarK2,))
 
 
 test_scenario = (scenario) -> begin
@@ -41,7 +42,7 @@ test_scenario = (scenario) -> begin
     (; xM, θP_true, θMs_true, xP, y_global_true, y_true, y_global_o, y_o, y_unc
     ) = gen_hybridproblem_synthetic(rng, prob; scenario);
 
-    g, ϕg0 = get_hybridproblem_MLapplicator(prob; scenario);
+    g, ϕg0 = @inferred get_hybridproblem_MLapplicator(prob; scenario);
     f = get_hybridproblem_PBmodel(prob; scenario, use_all_sites = false)
     f_pred = get_hybridproblem_PBmodel(prob; scenario, use_all_sites = true)
 
@@ -57,66 +58,79 @@ test_scenario = (scenario) -> begin
     # transM = Stacked(elementwise(identity), elementwise(exp))
     #transM = Stacked(elementwise(identity), elementwise(exp), elementwise(exp)) # test mismatch
     ϕunc0 = init_hybrid_ϕunc(cor_ends, zero(FT))
+    hpints = HybridProblemInterpreters(prob; scenario)
     (; ϕ, transPMs_batch, interpreters, get_transPMs, get_ca_int_PMs) = init_hybrid_params(
-        θP_true, θMs_true[:, 1], cor_ends, ϕg0, n_batch; transP, transM);
+        θP_true, θMs_true[:, 1], cor_ends, ϕg0, hpints; transP, transM);
+    # @descend_code_warntype init_hybrid_params(θP_true, θMs_true[:, 1], cor_ends, ϕg0, n_batch; transP, transM)
+    # @descend_code_warntype CA.ComponentVector(nt)
     ϕ_ini = ϕ
-    transform_tools = CP.setup_transform_ζ(transP, transM, interpreters.PMs)
+    transform_tools = @inferred CP.setup_transform_ζ(transP, transM, get_int_PMst_batch(hpints))
+    int_PMs = get_int_PMst_batch(hpints)
 
     if ggdev isa MLDataDevices.AbstractGPUDevice
-        scenario_flux = (scenario..., :use_Flux, :use_gpu)
+        scenario_flux = Val((CP._val_value(scenario)..., :use_Flux, :use_gpu))
         g_flux, ϕg0_flux_cpu = get_hybridproblem_MLapplicator(prob; scenario = scenario_flux)
         g_gpu = ggdev(g_flux)
     end;
 
-    ζs, σ = CP.generate_ζ(
-        rng, g, ϕ_ini, xM[:, 1:n_batch];
-        n_MC = 8, cor_ends, pbm_covar_indices, 
-        int_unc = interpreters.unc, int_μP_ϕg_unc=interpreters.μP_ϕg_unc, int_PMs=interpreters.PMs)
 
-    @testset "generate_ζ $(last(scenario))" begin
+    ζs, σ = @inferred (
+    # @descend_code_warntype (
+        CP.generate_ζ(
+        rng, g, ϕ_ini, xM[:, 1:n_batch];
+        n_MC, cor_ends, pbm_covar_indices, 
+        int_unc = interpreters.unc, int_μP_ϕg_unc=interpreters.μP_ϕg_unc, 
+        int_PMs)
+    )
+
+    @testset "generate_ζ $(last(CP._val_value(scenario)))" begin
         # xMtest = vcat(xM, xM[1:1,:])
         # ζ, σ = CP.generate_ζ(
         #     rng, g, ϕ_ini, xMtest[:, 1:n_batch], map(get_concrete, interpreters);
         #     n_MC = 8, cor_ends, pbm_covar_indices)
-        @test ζs isa Matrix
+        @test ζs isa AbstractMatrix
+        @test size(ζs) == (n_MC, length(int_PMs))
         gr = Zygote.gradient(
             # ϕ -> sum(CP.generate_ζ(
             #     rng, g, ϕ, xMtest[:, 1:n_batch], map(get_concrete, interpreters);
             #     n_MC = 8, cor_ends, pbm_covar_indices)[1]),
-            ϕ -> sum(CP.generate_ζ(
+            ϕ -> sum(first(CP.generate_ζ(
                 rng, g, ϕ, xM[:, 1:n_batch];
                 n_MC = 8, cor_ends, pbm_covar_indices,
-                int_unc = interpreters.unc, int_μP_ϕg_unc=interpreters.μP_ϕg_unc, int_PMs=interpreters.PMs
-                )[1]),
+                int_unc = interpreters.unc, int_μP_ϕg_unc=interpreters.μP_ϕg_unc, int_PMs
+                ))),
             CA.getdata(ϕ_ini))
         @test gr[1] isa Vector
     end;
 
     if ggdev isa MLDataDevices.AbstractGPUDevice
-        @testset "generate_ζ gpu $(last(scenario))" begin
+        @testset "generate_ζ gpu $(last(CP._val_value(scenario)))" begin
             ϕ = ggdev(CA.getdata(ϕ_ini))
             @test g_gpu.μ isa GPUArraysCore.AbstractGPUArray
             xMg_batch = ggdev(xM[:, 1:n_batch])
-            ζ, σ = CP.generate_ζ(
+            ζ, σ = @inferred (
+                # @descend_code_warntype (
+                CP.generate_ζ(
                 rng, g_gpu, ϕ, xMg_batch;
-                n_MC = 8, cor_ends, pbm_covar_indices,
-                int_unc = interpreters.unc, int_μP_ϕg_unc=interpreters.μP_ϕg_unc, int_PMs=interpreters.PMs
-                )
-            @test ζ isa GPUArraysCore.AbstractGPUMatrix
+                n_MC, cor_ends, pbm_covar_indices,
+                int_unc = interpreters.unc, int_μP_ϕg_unc=interpreters.μP_ϕg_unc, int_PMs
+                ))
+            @test ζ isa Union{GPUArraysCore.AbstractGPUMatrix, 
+                LinearAlgebra.Adjoint{FT, <: GPUArraysCore.AbstractGPUMatrix}} 
             @test eltype(ζ) == FT
+            @test size(ζs) == (n_MC, length(int_PMs))
             gr = Zygote.gradient(
-                ϕ -> sum(CP.generate_ζ(
+                ϕ -> sum(first(CP.generate_ζ(
                     rng, g_gpu, ϕ, xMg_batch;
-                    n_MC = 8, cor_ends, pbm_covar_indices,
-                    int_unc = interpreters.unc, int_μP_ϕg_unc=interpreters.μP_ϕg_unc, int_PMs=interpreters.PMs
-                    )[1]),
+                    n_MC, cor_ends, pbm_covar_indices,
+                    int_unc = interpreters.unc, int_μP_ϕg_unc=interpreters.μP_ϕg_unc, int_PMs
+                    ))),
                 ϕ)
             @test gr[1] isa GPUArraysCore.AbstractGPUVector
         end
     end
 
     @testset "transform ζs" begin
-        n_MC = 3 #size(ζs,2)
         # reorder Ms columns so that first parameter of all sites is first
         # # transforming entire parameter set across n_MC most efficient but
         # # does not yield logdetjac
@@ -135,30 +149,35 @@ test_scenario = (scenario) -> begin
         # @test size(θsP) == (n_MC, n_θP)
         # @test size(θsMs) == (n_MC, n_batch, n_θM)
         # map by rows
-        ζ = ζs[:,1]
-        θP, θMs, logjac = CP.transform_ζ(ζ, transP, transM, interpreters.PMs)
+        ζ = ζs[1,:]
+        θP, θMs, logjac = CP.transform_ζ(ζ, transP, transM, int_PMs)
         @test size(θP) == (n_θP,)
         @test size(θMs) == (n_batch, n_θM)
         if ggdev isa MLDataDevices.AbstractGPUDevice
             ζdev = ggdev(ζ)
-            θP, θMs, logjac = CP.transform_ζ(ζdev, transP, transM, interpreters.PMs)
-            _transform_tools = CP.setup_transform_ζ(
-                transP, transM, interpreters.PMs)
+            θP, θMs, logjac = @inferred CP.transform_ζ(ζdev, transP, transM, int_PMs)
+            _transform_tools = @inferred CP.setup_transform_ζ(
+                transP, transM, int_PMs)
             gr = Zygote.gradient(ζdev) do ζdev
                 θP, θMs, logjac = CP.transform_ζ(ζdev, _transform_tools...)
                 sum(θP) + sum(θMs) + logjac
-            end
+            end;
             @test eltype(gr[1]) == eltype(ζ)
         end
     end
 
 
-    @testset "neg_elbo_gtf cpu $(last(scenario))" begin
+    @testset "neg_elbo_gtf cpu $(last(CP._val_value(scenario)))" begin
         i_sites = 1:n_batch
-        cost = neg_elbo_gtf(rng, ϕ_ini, g, f, py,
+        cost = 
+        @inferred (
+        #@descend_code_warntype (
+            neg_elbo_gtf(rng, ϕ_ini, g, f, py,
             xM[:, i_sites], xP[:,i_sites], y_o[:, i_sites], y_unc[:, i_sites], i_sites,
             map(get_concrete, interpreters), transform_tools;
             cor_ends, pbm_covar_indices)
+            )
+        
         @test cost isa Float64
         gr = Zygote.gradient(
             ϕ -> neg_elbo_gtf(rng, ϕ, g, f, py,
@@ -170,15 +189,18 @@ test_scenario = (scenario) -> begin
     end;
 
     if ggdev isa MLDataDevices.AbstractGPUDevice
-        @testset "neg_elbo_gtf gpu $(last(scenario))" begin
+        @testset "neg_elbo_gtf gpu $(last(CP._val_value(scenario)))" begin
             i_sites = 1:n_batch
             ϕ = ggdev(CA.getdata(ϕ_ini))
             xMg_batch = ggdev(xM[:, i_sites])
             xP_batch = xP[:,i_sites] # used in f which runs on CPU
-            cost = neg_elbo_gtf(rng, ϕ, g_gpu, f, py,
+            cost = @inferred (
+                #@descend_code_warntype (
+                 neg_elbo_gtf(rng, ϕ, g_gpu, f, py,
                 xMg_batch, xP_batch, y_o[:, i_sites], y_unc[:, i_sites], i_sites,
                 map(get_concrete, interpreters), transform_tools;
                 n_MC = 3, cor_ends, pbm_covar_indices)
+            )
             @test cost isa Float64
             gr = Zygote.gradient(
                 ϕ -> neg_elbo_gtf(rng, ϕ, g_gpu, f, py,
@@ -198,14 +220,14 @@ test_scenario = (scenario) -> begin
     intm_PMst = get_concrete(ComponentArrayInterpreter(int_PMst, (n_sample_pred,)))
     int_unc = get_concrete(interpreters.unc)
 
-    @testset "predict_gf cpu $(last(scenario))" begin
+    @testset "predict_gf cpu $(last(CP._val_value(scenario)))" begin
         # intm_PMs_gen = get_ca_int_PMs(n_site)
         # trans_PMs_gen = get_transPMs(n_site)
         # @test length(intm_PMs_gen) == 402
         # @test trans_PMs_gen.length_in == 402
         (; θs, y, intm_PMst) = 
         #Cthulhu.@descend_code_warntype (
-        #@inferred (
+        @inferred (
         predict_gf(rng, g, f_pred, ϕ_ini, xM, xP, map(get_concrete, interpreters),
             int_P, int_M;
             #get_transPMs, 
@@ -213,7 +235,7 @@ test_scenario = (scenario) -> begin
             get_ca_int_PMs, n_sample_pred, cor_ends, pbm_covar_indices,
             int_PMs, int_PMst, intm_PMst, int_unc
             )
-        #)
+        )
         @test θs isa CA.ComponentMatrix
         @test θs[:,1].P.r0 > 0
         @test size(θs,2) == n_sample_pred
@@ -222,7 +244,7 @@ test_scenario = (scenario) -> begin
     end
 
     if ggdev isa MLDataDevices.AbstractGPUDevice
-        @testset "predict_gf gpu $(last(scenario))" begin
+        @testset "predict_gf gpu $(last(CP._val_value(scenario)))" begin
             n_sample_pred = 200
             ϕ_ini_g = ggdev(CA.getdata(ϕ_ini))
             xMg = ggdev(xM)

--- a/test/test_hybridprobleminterpreters.jl
+++ b/test/test_hybridprobleminterpreters.jl
@@ -1,0 +1,80 @@
+using Test
+using HybridVariationalInference
+using HybridVariationalInference: HybridVariationalInference as CP
+using ComponentArrays: ComponentArrays as CA
+
+using MLDataDevices, GPUArraysCore
+import Zygote
+
+# import CUDA, cuDNN
+using Suppressor
+
+gdev = Suppressor.@suppress gpu_device() # not loaded CUDA
+cdev = cpu_device()
+
+scenario = Val((:default,))
+prob = DoubleMM.DoubleMMCase()
+
+ints = @inferred HybridProblemInterpreters(prob; scenario)
+θP, θM = @inferred get_hybridproblem_par_templates(prob; scenario)
+NS, NB = @inferred get_hybridproblem_n_site_and_batch(prob; scenario)
+
+@testset "HybridProblemInterpreters" begin
+    @test (@inferred get_int_P(ints)(CA.getdata(θP))) == θP
+    @test (@inferred get_int_M(ints)(CA.getdata(θM))) == θM
+    #
+    int_Ms_batch = get_concrete(ComponentArrayInterpreter(θM, (NB,)))
+    ms_vec = 1:length(int_Ms_batch)
+    @test (@inferred get_int_Ms_batch(ints)(ms_vec)) == int_Ms_batch(ms_vec)
+    int_Mst_batch = get_concrete(ComponentArrayInterpreter((NB,), θM))
+    @test (@inferred get_int_Mst_batch(ints)(ms_vec)) == int_Mst_batch(ms_vec)
+    #
+    int_Ms_site = get_concrete(ComponentArrayInterpreter(θM, (NS,)))
+    ms_vec = 1:length(int_Ms_site)
+    @test (@inferred get_int_Ms_site(ints)(ms_vec)) == int_Ms_site(ms_vec)
+    int_Mst_site = get_concrete(ComponentArrayInterpreter((NS,), θM))
+    @test (@inferred get_int_Mst_site(ints)(ms_vec)) == int_Mst_site(ms_vec)
+    #
+    pms_ca = CA.ComponentVector(P = θP, Ms = int_Ms_batch(1:length(int_Ms_batch)))
+    pms_vec = CA.getdata(pms_ca)
+    #int_PMs_batch = get_concrete(ComponentArrayInterpreter(pms_ca))
+    @test (@inferred get_int_PMs_batch(ints)(pms_vec)) == pms_ca
+    pmst_ca = CA.ComponentVector(P = θP, Ms = int_Mst_batch(1:length(int_Mst_batch)))
+    pmst_vec = CA.getdata(pmst_ca)
+    @test (@inferred get_int_PMst_batch(ints)(pmst_vec)) == pmst_ca
+    #
+    pms_ca = CA.ComponentVector(P = θP, Ms = int_Ms_site(1:length(int_Ms_site)))
+    pms_vec = CA.getdata(pms_ca)
+    @test (@inferred get_int_PMs_site(ints)(pms_vec)) == pms_ca
+    pmst_ca = CA.ComponentVector(P = θP, Ms = int_Mst_site(1:length(int_Mst_site)))
+    pmst_vec = CA.getdata(pmst_ca)
+    @test (@inferred get_int_PMst_site(ints)(pmst_vec)) == pmst_ca
+end;
+
+@testset "stack_ca_int" begin
+    int_Mst_batch = get_int_Mst_batch(ints)
+    pmst_ca = CA.ComponentVector(P = θP, Ms = int_Mst_batch(1:length(int_Mst_batch)))
+    n_pred = 5
+    mmst_vec = repeat(CA.getdata(pmst_ca)', n_pred) # column per parameter
+    int_PMst_batch = @inferred get_int_PMst_batch(ints)
+    intm_PMst_batch = @inferred stack_ca_int(Val((n_pred,)), int_PMst_batch)
+    mmst = @inferred intm_PMst_batch(mmst_vec)
+    @test size(mmst[1, :Ms]) == (NB, length(θM))
+    @test all(mmst[:, :P][:, :r0] .== pmst_ca.P.r0)
+    #
+    # note the use of Val here -> arrays interpreted will by Any outside the context
+    @testset "stack_ca_int not inferred outside" begin 
+        tmpf = (mmst_vec;
+            intm_PMst_batch = @inferred stack_ca_int(Val((size(mmst_vec,1),)), int_PMst_batch)
+        ) -> begin
+            # good practise to help inference by providing a hint to the eltype
+            (@inferred intm_PMst_batch(mmst_vec))::CA.ComponentMatrix{eltype(mmst_vec),typeof(mmst_vec)}
+        end
+        res = tmpf(mmst_vec)
+        @test_broken @inferred tmpf(mmst_vec)
+        # but supplying the extended array, its inferred in this context
+        intm_PMst_batch2 = @inferred stack_ca_int(Val((size(mmst_vec,1),)), int_PMst_batch)
+        @inferred tmpf(mmst_vec; intm_PMst_batch = intm_PMst_batch2)
+    end
+end
+

--- a/test/test_sample_zeta.jl
+++ b/test/test_sample_zeta.jl
@@ -36,7 +36,7 @@ cor_ends = (P=1:n_θP, M=[n_θM])
 ρsM = zeros(FT, get_cor_count(cor_ends.M)) .+ FT(0.02)
 
 ϕunc = CA.ComponentVector(;
-    logσ2_logP=fill(FT(-10.0), n_θP),
+    logσ2_ζP=fill(FT(-10.0), n_θP),
     coef_logσ2_ζMs=reduce(hcat, (FT[-10.0, 0.0] for _ in 1:n_θM)),
     ρsP,
     ρsM)

--- a/test/test_util_ca.jl
+++ b/test/test_util_ca.jl
@@ -1,0 +1,19 @@
+using Test
+using HybridVariationalInference
+using HybridVariationalInference: HybridVariationalInference as CP
+using ComponentArrays: ComponentArrays as CA
+
+@testset "compose_axes" begin
+    @test (@inferred CP._add_interval(;ranges=(Val(1:3),), length = Val(2))) == (Val(1:3), Val(4:5))
+    ls = Val.((3,1,2))
+    @test (@inferred CP._construct_invervals(;lengths=ls)) == Val.((1:3, 4:4, 5:6))
+    v1 = CA.ComponentVector(A=1:3)
+    v2 = CA.ComponentVector(B=1:2)
+    v3 = CA.ComponentVector(P=(x=1, y=2), Ms=zeros(3,2))
+    nt = (;C1=v1, C2=v2, C3=v3)
+    vt = CA.ComponentVector(; nt...)
+    axs = map(CA.getaxes, nt)
+    axc = @inferred CP.compose_axes(axs)
+    @test axc == CA.getaxes(vt)[1] 
+end
+


### PR DESCRIPTION
Rather than relying on marsheling it via ComponentArrayInterpreter.

This allows treating different arrangement of dimensions n_site x n_par x_MC depending on next step.

Otherwise transposing n_par x n_site within parameter within parameter vector quickly becomes messy.